### PR TITLE
German update for 3.0.5 small fixes

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -92,10 +92,10 @@
     <string name="action_cancel">Abbrechen</string>
     <string name="title_warning">Warnung</string>
     <string name="dialog_adobe_dead">Hinweis: Google hat einige Änderungen in Android 4.4+ eingeführt und Adobe Flash ist dadurch nicht mehr möglich!</string>
-    <string name="dialog_adobe_not_installed">Adobe Flash Player wurde erkannt.\nBitte installieren Sie den Flash Player.</string>
+    <string name="dialog_adobe_not_installed">Adobe Flash Player wurde nicht erkannt.\nBitte installieren Sie den Flash Player.</string>
     <string name="dialog_adobe_unsupported">Adobe Flash unterstützt Andoid 4.2 und höher nicht mehr und kann zu Abstürzen führen. Bitte melden Sie keine Probleme, wenn Sie Flash aktiviert haben!</string>
     <string name="title_user_agent">User-Agent</string>
-    <string name="title_download_location">Ort herunterladen</string>
+    <string name="title_download_location">Download-Verzeichnis festlegen</string>
     <string name="title_custom_homepage">Benutzerdefinierte Startseite</string>
     <string name="action_webpage">Webseite</string>
     <string name="dialog_reflow_warning">Hinweis: Google hat einige Änderungen in Android 4.4+ eingeführt und eine Textumformierung ist nicht mehr möglich!</string>
@@ -117,7 +117,7 @@
     <string name="hint_url">URL</string>
     <string name="title_edit_bookmark">Lesezeichen bearbeiten</string>
     <string name="action_edit">Bearbeiten</string>
-    <string name="action_incognito">Inkognito-Tab</string>
+    <string name="action_incognito">Neuer Inkognito-Tab</string>
     <string name="hello_world">Hallo Welt!</string>
     <string name="action_homepage">Standard</string>
     <string name="action_back">Zurück</string>


### PR DESCRIPTION
Miss two strings: "History Cleared" and "Cookies Cleared" are not available in original translation file.
