### PR TITLE
New "Custom URL" option for search engine. Allow stuff like 'http://yubnub.org/parser/parse?command=' or 'http://mypersonalserver.net/woot.cgi?whatever='

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -67,6 +67,7 @@
     <string name="weird_look">(Websites may look weird)</string>
     <string name="search">Search Engine</string>
     <string name="search_hint">Search</string>
+    <string name="custom_url">Custom URL</string>
     <string name="wideViewPort">Use wide viewport</string>
     <string name="overViewMode">Load pages in overview mode</string>
     <string name="restore">Restore lost tabs on start</string>

--- a/src/acr/browser/barebones/activities/BrowserActivity.java
+++ b/src/acr/browser/barebones/activities/BrowserActivity.java
@@ -1563,6 +1563,12 @@ public class BrowserActivity extends Activity implements OnTouchListener {
 		defaultUser = user; // setting mobile user
 		// agent
 		switch (settings.getInt("search", 1)) {
+		case 0:
+			mSearch = settings.getString("searchurl", FinalVariables.GOOGLE_SEARCH);
+			if(!mSearch.startsWith("http://") && ! mSearch.startsWith("https://") ) {
+				mSearch = FinalVariables.GOOGLE_SEARCH;
+			}
+			break;
 		case 1:
 			mSearch = FinalVariables.GOOGLE_SEARCH;
 			break;

--- a/src/acr/browser/barebones/activities/IncognitoModeActivity.java
+++ b/src/acr/browser/barebones/activities/IncognitoModeActivity.java
@@ -1536,6 +1536,13 @@ public class IncognitoModeActivity extends Activity implements OnTouchListener {
 		defaultUser = user; // setting mobile user
 		// agent
 		switch (settings.getInt("search", 1)) {
+		case 0:
+			SEARCH = settings.getString("searchurl", FinalVariables.GOOGLE_SEARCH);
+			if(!SEARCH.startsWith("http://") && ! SEARCH.startsWith("https://") ) {
+				SEARCH = FinalVariables.GOOGLE_SEARCH;
+			}
+			break;
+
 		case 1:
 			SEARCH = FinalVariables.GOOGLE_SEARCH;
 			break;

--- a/src/acr/browser/barebones/activities/SettingsActivity.java
+++ b/src/acr/browser/barebones/activities/SettingsActivity.java
@@ -38,6 +38,7 @@ public class SettingsActivity extends Activity {
 	static SharedPreferences.Editor mEditPrefs;
 	static int agentChoice;
 	static String homepage;
+	static String searchurl;
 	static TextView agentText;
 	static String agent;
 	static TextView download;
@@ -74,6 +75,9 @@ public class SettingsActivity extends Activity {
 		searchText = (TextView) findViewById(R.id.searchText);
 
 		switch (settings.getInt("search", 1)) {
+		case 0:
+			searchText.setText("Custom URL");
+			break;
 		case 1:
 			searchText.setText("Google");
 			break;
@@ -226,20 +230,24 @@ public class SettingsActivity extends Activity {
 						SettingsActivity.this);
 				picker.setTitle(getResources().getString(
 						R.string.title_search_engine));
-				CharSequence[] chars = { "Google", "Bing", "Yahoo",
+				CharSequence[] chars = { getResources().getString(R.string.custom_url),
+						"Google", "Bing", "Yahoo",
 						"StartPage", "DuckDuckGo (Privacy)" , "Baidu (Chinese)", "Yandex (Russian)", "DuckDuckGo Lite (Privacy)"};
 
 				int n = settings.getInt("search", 1);
 
-				picker.setSingleChoiceItems(chars, n - 1,
+				picker.setSingleChoiceItems(chars, n,
 						new DialogInterface.OnClickListener() {
 
 							@Override
 							public void onClick(DialogInterface dialog,
 									int which) {
-								mEditPrefs.putInt("search", which + 1);
+								mEditPrefs.putInt("search", which);
 								mEditPrefs.commit();
-								switch (which + 1) {
+								switch (which) {
+								case 0:
+									searchUrlPicker();
+									break;
 								case 1:
 									searchText.setText("Google");
 									break;
@@ -281,6 +289,33 @@ public class SettingsActivity extends Activity {
 
 		});
 	}
+
+	public void searchUrlPicker() {
+		final AlertDialog.Builder urlPicker = new AlertDialog.Builder(
+				SettingsActivity.this);
+		
+		urlPicker.setTitle(getResources().getString(
+				R.string.custom_url));
+		final EditText getSearchUrl = new EditText(SettingsActivity.this);
+
+		searchurl = settings.getString("searchurl", FinalVariables.GOOGLE_SEARCH);
+		getSearchUrl.setText(searchurl);
+		urlPicker.setView(getSearchUrl);
+		urlPicker.setPositiveButton(
+				getResources().getString(R.string.action_ok),
+				new DialogInterface.OnClickListener() {
+
+					@Override
+					public void onClick(DialogInterface dialog, int which) {
+						String text = getSearchUrl.getText().toString();
+						mEditPrefs.putString("searchurl", text);
+						mEditPrefs.commit();
+						searchText.setText( getResources().getString(R.string.custom_url) + ": " + text);
+					}
+				});
+		urlPicker.show();
+	}
+
 
 	public void clickListenerForCheckBoxes(RelativeLayout one,
 			RelativeLayout two, RelativeLayout three, final CheckBox loc,


### PR DESCRIPTION
- Pops up txt dialog when selected, initial default same as builtin google url
- Active when "search" pref = 0, adds "searchurl" string pref
- Default remains '1' (builtin google url)
