### PR TITLE
make the agent picker remember the previous value

### DIFF
--- a/src/acr/browser/lightning/SettingsActivity.java
+++ b/src/acr/browser/lightning/SettingsActivity.java
@@ -721,6 +721,7 @@ public class SettingsActivity extends Activity {
 
 		agentStringPicker.setTitle(getResources().getString(R.string.title_user_agent));
 		final EditText getAgent = new EditText(this);
+		getAgent.append(mPreferences.getString(PreferenceConstants.USER_AGENT_STRING, ""));
 		agentStringPicker.setView(getAgent);
 		agentStringPicker.setPositiveButton(getResources().getString(R.string.action_ok),
 				new DialogInterface.OnClickListener() {


### PR DESCRIPTION
Saying you might sometimes accidentally click "yes"
when editing user agent string and then the previous setting
goes away or there is a typo in the customized string
and you want to modify it slightly.

And making the agent picker remember the previous value
solves all the problems above :)
