### PR TITLE
Fix bug with uploading files on KitKat

### DIFF
--- a/proguard-project.txt
+++ b/proguard-project.txt
@@ -35,6 +35,13 @@
 -keep public class * extends android.preference.Preference
 -keep public class com.android.vending.licensing.ILicensingService
 
+# Without this rule, openFileChooser does not get called on KitKat
+-keep class acr.browser.lightning.LightningView$LightningChromeClient {
+	void openFileChooser(android.webkit.ValueCallback);
+	void openFileChooser(android.webkit.ValueCallback,java.lang.String);
+	void openFileChooser(android.webkit.ValueCallback,java.lang.String,java.lang.String);
+}
+
 -keepclasseswithmembernames class * {
     native <methods>;
 }

--- a/proguard-project.txt
+++ b/proguard-project.txt
@@ -38,8 +38,8 @@
 # Without this rule, openFileChooser does not get called on KitKat
 -keep class acr.browser.lightning.LightningView$LightningChromeClient {
 	void openFileChooser(android.webkit.ValueCallback);
-	void openFileChooser(android.webkit.ValueCallback,java.lang.String);
-	void openFileChooser(android.webkit.ValueCallback,java.lang.String,java.lang.String);
+	void openFileChooser(android.webkit.ValueCallback, java.lang.String);
+	void openFileChooser(android.webkit.ValueCallback, java.lang.String, java.lang.String);
 }
 
 -keepclasseswithmembernames class * {

--- a/src/acr/browser/lightning/BrowserActivity.java
+++ b/src/acr/browser/lightning/BrowserActivity.java
@@ -1876,7 +1876,7 @@ public class BrowserActivity extends Activity implements BrowserController {
 
 	@Override
 	/**
-	 * used to allow uploading into the browser, doesn't get called in KitKat :(
+	 * used to allow uploading into the browser
 	 */
 	protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
 		if (requestCode == 1) {


### PR DESCRIPTION
This commit fixes #81. The bug was caused by Proguard messing with the
code. This commit adds a simple Proguard rule that prevents it from
doing so.