### PR TITLE
Not allow to zoom in the internal pages.

### DIFF
--- a/src/acr/browser/lightning/BookmarkPage.java
+++ b/src/acr/browser/lightning/BookmarkPage.java
@@ -7,7 +7,7 @@ public class BookmarkPage {
 
 	public static final String FILENAME = "bookmarks.html";
 	
-	public static final String HEADING = "<!DOCTYPE html><html xmlns=\"http://www.w3.org/1999/xhtml\"><head><meta content=\"en-us\" http-equiv=\"Content-Language\" /><meta content=\"text/html; charset=utf-8\" http-equiv=\"Content-Type\" /><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><title>"
+	public static final String HEADING = "<!DOCTYPE html><html xmlns=\"http://www.w3.org/1999/xhtml\"><head><meta content=\"en-us\" http-equiv=\"Content-Language\" /><meta content=\"text/html; charset=utf-8\" http-equiv=\"Content-Type\" /><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no\"><title>"
 			+ BrowserApp.getAppContext().getString(R.string.action_bookmarks)
 			+ "</title></head><style>body { background: #e1e1e1; max-width:100%; min-height:100%;}#content {width:100%; max-width:800px; margin:0 auto; text-align:center;}.box { vertical-align:middle;text-align:center;position:relative; display: inline-block; height: 100px; width: 100px; margin: 10px; background-color:#fff;box-shadow: 0px 3px rgba( 0, 0, 0, 0.1 );font-family: Arial;color: #444;font-size: 12px;-moz-border-radius: 2px;-webkit-border-radius: 2px;border-radius: 2px;}.stuff {height: 100px; width: 100px;vertical-align:middle;text-align:center; display: table-cell;}p.ellipses {width:90px; white-space: nowrap; overflow: hidden;text-align:center;margin:auto; text-overflow: ellipsis; -o-text-overflow: ellipsis; -ms-text-overflow: ellipsis;}.box a { width: 100%; height: 100%; position: absolute; left: 0; top: 0;}</style><body> <div id=\"content\">";
 

--- a/src/acr/browser/lightning/HistoryPage.java
+++ b/src/acr/browser/lightning/HistoryPage.java
@@ -15,7 +15,7 @@ public class HistoryPage {
 
 	private static final String FILENAME = "history.html";
 
-	private static final String HEADING = "<!DOCTYPE html><html xmlns=\"http://www.w3.org/1999/xhtml\"><head><meta content=\"en-us\" http-equiv=\"Content-Language\" /><meta content=\"text/html; charset=utf-8\" http-equiv=\"Content-Type\" /><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><title>"
+	private static final String HEADING = "<!DOCTYPE html><html xmlns=\"http://www.w3.org/1999/xhtml\"><head><meta content=\"en-us\" http-equiv=\"Content-Language\" /><meta content=\"text/html; charset=utf-8\" http-equiv=\"Content-Type\" /><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no\"><title>"
 			+ BrowserApp.getAppContext().getString(R.string.action_history)
 			+ "</title></head><style>body { background: #e1e1e1;}.box { vertical-align:middle;position:relative; display: block; margin: 10px;padding-left:10px;padding-right:10px;padding-top:5px;padding-bottom:5px; background-color:#fff;box-shadow: 0px 3px rgba( 0, 0, 0, 0.1 );font-family: Arial;color: #444;font-size: 12px;-moz-border-radius: 2px;-webkit-border-radius: 2px;border-radius: 2px;}.box a { width: 100%; height: 100%; position: absolute; left: 0; top: 0;}.black {color: black;font-size: 15px;font-family: Arial; white-space: nowrap; overflow: hidden;margin:auto; text-overflow: ellipsis; -o-text-overflow: ellipsis; -ms-text-overflow: ellipsis;}.font {color: gray;font-size: 10px;font-family: Arial; white-space: nowrap; overflow: hidden;margin:auto; text-overflow: ellipsis; -o-text-overflow: ellipsis; -ms-text-overflow: ellipsis;}</style><body><div id=\"content\">";
 

--- a/src/acr/browser/lightning/HomepageVariables.java
+++ b/src/acr/browser/lightning/HomepageVariables.java
@@ -9,7 +9,7 @@ public class HomepageVariables {
 			+ "<head>"
 			+ "<meta content=\"en-us\" http-equiv=\"Content-Language\" />"
 			+ "<meta content=\"text/html; charset=utf-8\" http-equiv=\"Content-Type\" />"
-			+ "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">"
+			+ "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no\">"
 			+ "<title>"
 			+ BrowserApp.getAppContext().getString(R.string.home)
 			+ "</title>"


### PR DESCRIPTION
This commit prevents an user from zooming in the Home Page, Bookmarks Page and History Page.

On some devices, for examlpe, some tablets with low dpi, tapping the search bar in the Home Page would zoom the browser in about 25% and then open the keyboard. That looks weird.

Also, the Lightning Browser does not allow zooming in the Settings menu and the Tabs/Bookmarks sidebars. Allowing the user to zoom in one place of the UI and not in the other is inconsitent.