### PR TITLE
Support I2P (and other proxies in future)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,4 +39,5 @@ dependencies {
     compile 'com.android.support:palette-v7:22.1.1'
     compile 'com.android.support:appcompat-v7:22.1.1'
     compile 'org.jsoup:jsoup:1.8.1'
+    compile 'net.i2p.android:client:0.6@aar'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,5 +39,5 @@ dependencies {
     compile 'com.android.support:palette-v7:22.1.1'
     compile 'com.android.support:appcompat-v7:22.1.1'
     compile 'org.jsoup:jsoup:1.8.1'
-    compile 'net.i2p.android:client:0.6@aar'
+    compile 'net.i2p.android:client:0.7@aar'
 }

--- a/app/proguard-project.txt
+++ b/app/proguard-project.txt
@@ -77,3 +77,8 @@
 # Don't warn about those in case this app is linking against an older
 # platform version.  We know about them, and they are safe.
 -dontwarn android.support.**
+
+# The I2P Java API bundled inside the I2P Android client library contains a
+# method that references classes in javax.naming that Android doesn't have. But
+# the method never uses those classes on Android, and is safe.
+-dontwarn net.i2p.crypto.CertUtil

--- a/app/proguard-project.txt
+++ b/app/proguard-project.txt
@@ -78,7 +78,8 @@
 # platform version.  We know about them, and they are safe.
 -dontwarn android.support.**
 
-# The I2P Java API bundled inside the I2P Android client library contains a
-# method that references classes in javax.naming that Android doesn't have. But
-# the method never uses those classes on Android, and is safe.
+# The I2P Java API bundled inside the I2P Android client library contains
+# references to javax.naming classes that Android doesn't have. But those
+# classes are never used on Android, and it is safe to ignore the warnings.
 -dontwarn net.i2p.crypto.CertUtil
+-dontwarn org.apache.http.conn.ssl.DefaultHostnameVerifier

--- a/app/src/main/java/acr/browser/lightning/activity/BrowserActivity.java
+++ b/app/src/main/java/acr/browser/lightning/activity/BrowserActivity.java
@@ -650,6 +650,20 @@ public class BrowserActivity extends ThemableActivity implements BrowserControll
 
 	}
 
+	public boolean isProxyReady() {
+		if (mPreferences.getProxyChoice() == 2) {
+			if (!mI2PHelper.isI2PAndroidRunning()) {
+				Utils.showToast(this, getString(R.string.i2p_not_running));
+				return false;
+			} else if (!mI2PHelper.areTunnelsActive()) {
+				Utils.showToast(this, getString(R.string.i2p_tunnels_not_ready));
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	private boolean isTablet() {
 		return (getResources().getConfiguration().screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK) == Configuration.SCREENLAYOUT_SIZE_XLARGE;
 	}

--- a/app/src/main/java/acr/browser/lightning/activity/BrowserActivity.java
+++ b/app/src/main/java/acr/browser/lightning/activity/BrowserActivity.java
@@ -614,11 +614,11 @@ public class BrowserActivity extends ThemableActivity implements BrowserControll
 		int port;
 
 		switch (mPreferences.getProxyChoice()) {
-			case 0:
+			case Constants.NO_PROXY:
 				// We shouldn't be here
 				return;
 
-			case 1:
+			case Constants.PROXY_ORBOT:
 				OrbotHelper oh = new OrbotHelper(this);
 				if (!oh.isOrbotRunning()) {
 					oh.requestOrbotStart(this);
@@ -627,7 +627,7 @@ public class BrowserActivity extends ThemableActivity implements BrowserControll
 				port = 8118;
 				break;
 
-			case 2:
+			case Constants.PROXY_I2P:
 				mI2PProxyInitialized = true;
 				if (mI2PHelperBound && !mI2PHelper.isI2PAndroidRunning()) {
 					mI2PHelper.requestI2PAndroidStart(this);
@@ -651,7 +651,7 @@ public class BrowserActivity extends ThemableActivity implements BrowserControll
 	}
 
 	public boolean isProxyReady() {
-		if (mPreferences.getProxyChoice() == 2) {
+		if (mPreferences.getProxyChoice() == Constants.PROXY_I2P) {
 			if (!mI2PHelper.isI2PAndroidRunning()) {
 				Utils.showToast(this, getString(R.string.i2p_not_running));
 				return false;
@@ -1501,7 +1501,7 @@ public class BrowserActivity extends ThemableActivity implements BrowserControll
 	@Override
 	protected void onStart() {
 		super.onStart();
-		if (mPreferences.getProxyChoice() == 2) {
+		if (mPreferences.getProxyChoice() == Constants.PROXY_I2P) {
 			// Try to bind to I2P Android
 			mI2PHelper.bind(new I2PAndroidHelper.Callback() {
 				@Override

--- a/app/src/main/java/acr/browser/lightning/activity/BrowserActivity.java
+++ b/app/src/main/java/acr/browser/lightning/activity/BrowserActivity.java
@@ -588,11 +588,12 @@ public class BrowserActivity extends ThemableActivity implements BrowserControll
 					public void onClick(DialogInterface dialog, int which) {
 						switch (which) {
 							case DialogInterface.BUTTON_POSITIVE:
-								mPreferences.setProxyChoice(orbotInstalled ? 1 : 2);
+								mPreferences.setProxyChoice(orbotInstalled ?
+										Constants.PROXY_ORBOT : Constants.PROXY_I2P);
 								initializeProxy();
 								break;
 							case DialogInterface.BUTTON_NEGATIVE:
-								mPreferences.setProxyChoice(0);
+								mPreferences.setProxyChoice(Constants.NO_PROXY);
 								break;
 						}
 					}

--- a/app/src/main/java/acr/browser/lightning/activity/BrowserActivity.java
+++ b/app/src/main/java/acr/browser/lightning/activity/BrowserActivity.java
@@ -184,6 +184,8 @@ public class BrowserActivity extends ThemableActivity implements BrowserControll
 
 	// Helper
 	private I2PAndroidHelper mI2PHelper;
+	private boolean mI2PHelperBound;
+	private boolean mI2PProxyInitialized;
 
 	// Constant
 	private static final int API = android.os.Build.VERSION.SDK_INT;
@@ -626,7 +628,8 @@ public class BrowserActivity extends ThemableActivity implements BrowserControll
 				break;
 
 			case 2:
-				if (!mI2PHelper.isI2PAndroidRunning()) {
+				mI2PProxyInitialized = true;
+				if (mI2PHelperBound && !mI2PHelper.isI2PAndroidRunning()) {
 					mI2PHelper.requestI2PAndroidStart(this);
 				}
 				host = "localhost";
@@ -807,6 +810,7 @@ public class BrowserActivity extends ThemableActivity implements BrowserControll
 			} catch (Exception e) {
 				e.printStackTrace();
 			}
+			mI2PProxyInitialized = false;
 		}
 	}
 
@@ -1468,6 +1472,7 @@ public class BrowserActivity extends ThemableActivity implements BrowserControll
 	protected void onStop() {
 		super.onStop();
 		mI2PHelper.unbind();
+		mI2PHelperBound = false;
 	}
 
 	@Override
@@ -1484,7 +1489,14 @@ public class BrowserActivity extends ThemableActivity implements BrowserControll
 		super.onStart();
 		if (mPreferences.getProxyChoice() == 2) {
 			// Try to bind to I2P Android
-			mI2PHelper.bind();
+			mI2PHelper.bind(new I2PAndroidHelper.Callback() {
+				@Override
+				public void onI2PAndroidBound() {
+					mI2PHelperBound = true;
+					if (mI2PProxyInitialized && !mI2PHelper.isI2PAndroidRunning())
+						mI2PHelper.requestI2PAndroidStart(BrowserActivity.this);
+				}
+			});
 		}
 	}
 

--- a/app/src/main/java/acr/browser/lightning/activity/SettingsActivity.java
+++ b/app/src/main/java/acr/browser/lightning/activity/SettingsActivity.java
@@ -98,7 +98,10 @@ public class SettingsActivity extends ThemableSettingsActivity {
 		mProxyChoiceName = (TextView) findViewById(R.id.proxyChoiceName);
 		mProxyChoices = this.getResources().getStringArray(R.array.proxy_choices_array);
 		int choice = mPreferences.getProxyChoice();
-		mProxyChoiceName.setText(mProxyChoices[choice]);
+		if (choice == Constants.PROXY_MANUAL)
+			mProxyChoiceName.setText(mPreferences.getProxyHost() + ":" + mPreferences.getProxyPort());
+		else
+			mProxyChoiceName.setText(mProxyChoices[choice]);
 
 		CheckBox flash = (CheckBox) findViewById(R.id.cbFlash);
 		CheckBox adblock = (CheckBox) findViewById(R.id.cbAdblock);
@@ -337,11 +340,38 @@ public class SettingsActivity extends ThemableSettingsActivity {
 					ih.promptToInstall(this);
 				}
 				break;
+
+			case Constants.PROXY_MANUAL:
+				manualProxyPicker();
+				break;
 		}
 
 		mPreferences.setProxyChoice(choice);
 		if (choice < mProxyChoices.length)
 			mProxyChoiceName.setText(mProxyChoices[choice]);
+	}
+
+	public void manualProxyPicker() {
+		View v = getLayoutInflater().inflate(R.layout.picker_manual_proxy, null);
+		final EditText eProxyHost = (EditText) v.findViewById(R.id.proxyHost);
+		final EditText eProxyPort = (EditText) v.findViewById(R.id.proxyPort);
+		eProxyHost.setText(mPreferences.getProxyHost());
+		eProxyPort.setText(Integer.toString(mPreferences.getProxyPort()));
+
+		new AlertDialog.Builder(mActivity)
+				.setTitle(R.string.manual_proxy)
+				.setView(v)
+				.setPositiveButton(R.string.action_ok, new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialogInterface, int i) {
+						String proxyHost = eProxyHost.getText().toString();
+						int proxyPort = Integer.parseInt(eProxyPort.getText().toString());
+						mPreferences.setProxyHost(proxyHost);
+						mPreferences.setProxyPort(proxyPort);
+						mProxyChoiceName.setText(proxyHost + ":" + proxyPort);
+					}
+				})
+				.show();
 	}
 
 	public void agentPicker() {

--- a/app/src/main/java/acr/browser/lightning/activity/SettingsActivity.java
+++ b/app/src/main/java/acr/browser/lightning/activity/SettingsActivity.java
@@ -322,18 +322,18 @@ public class SettingsActivity extends ThemableSettingsActivity {
 
 	private void setProxyChoice(int choice) {
 		switch (choice) {
-			case 1:
+			case Constants.PROXY_ORBOT:
 				OrbotHelper oh = new OrbotHelper(this);
 				if (!oh.isOrbotInstalled()) {
-					choice = 0;
+					choice = Constants.NO_PROXY;
 					Utils.showToast(mContext, getResources().getString(R.string.install_orbot));
 				}
 				break;
 
-			case 2:
+			case Constants.PROXY_I2P:
 				I2PAndroidHelper ih = new I2PAndroidHelper(this);
 				if (!ih.isI2PAndroidInstalled()) {
-					choice = 0;
+					choice = Constants.NO_PROXY;
 					ih.promptToInstall(this);
 				}
 				break;

--- a/app/src/main/java/acr/browser/lightning/activity/SettingsActivity.java
+++ b/app/src/main/java/acr/browser/lightning/activity/SettingsActivity.java
@@ -339,7 +339,6 @@ public class SettingsActivity extends ThemableSettingsActivity {
 				break;
 		}
 
-		mPreferences.setUseProxy(choice != 0);
 		mPreferences.setProxyChoice(choice);
 		if (choice < mProxyChoices.length)
 			mProxyChoiceName.setText(mProxyChoices[choice]);

--- a/app/src/main/java/acr/browser/lightning/activity/SettingsActivity.java
+++ b/app/src/main/java/acr/browser/lightning/activity/SettingsActivity.java
@@ -22,11 +22,15 @@ import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.EditText;
+import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
+import android.widget.TextView;
 
+import net.i2p.android.ui.I2PAndroidHelper;
+
+import acr.browser.lightning.R;
 import acr.browser.lightning.constant.Constants;
 import acr.browser.lightning.preference.PreferenceManager;
-import acr.browser.lightning.R;
 import acr.browser.lightning.utils.Utils;
 import info.guardianproject.onionkit.ui.OrbotHelper;
 
@@ -36,6 +40,8 @@ public class SettingsActivity extends ThemableSettingsActivity {
 	private PreferenceManager mPreferences;
 	private Context mContext;
 	private Activity mActivity;
+	private CharSequence[] mProxyChoices;
+	private TextView mProxyChoiceName;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -69,7 +75,7 @@ public class SettingsActivity extends ThemableSettingsActivity {
 		layoutBlockAds.setEnabled(Constants.FULL_VERSION);
 		RelativeLayout layoutImages = (RelativeLayout) findViewById(R.id.layoutImages);
 		RelativeLayout layoutEnableJS = (RelativeLayout) findViewById(R.id.layoutEnableJS);
-		RelativeLayout layoutOrbot = (RelativeLayout) findViewById(R.id.layoutUseOrbot);
+		LinearLayout layoutProxyChoice = (LinearLayout) findViewById(R.id.layoutProxyChoice);
 		RelativeLayout layoutColor = (RelativeLayout) findViewById(R.id.layoutColorMode);
 		RelativeLayout layoutBookmarks = (RelativeLayout) findViewById(R.id.layoutBookmarks);
 
@@ -89,12 +95,16 @@ public class SettingsActivity extends ThemableSettingsActivity {
 		boolean imagesBool = mPreferences.getBlockImagesEnabled();
 		boolean enableJSBool = mPreferences.getJavaScriptEnabled();
 
+		mProxyChoiceName = (TextView) findViewById(R.id.proxyChoiceName);
+		mProxyChoices = this.getResources().getStringArray(R.array.proxy_choices_array);
+		int choice = mPreferences.getProxyChoice();
+		mProxyChoiceName.setText(mProxyChoices[choice]);
+
 		CheckBox flash = (CheckBox) findViewById(R.id.cbFlash);
 		CheckBox adblock = (CheckBox) findViewById(R.id.cbAdblock);
 		adblock.setEnabled(Constants.FULL_VERSION);
 		CheckBox images = (CheckBox) findViewById(R.id.cbImageBlock);
 		CheckBox enablejs = (CheckBox) findViewById(R.id.cbJavascript);
-		CheckBox orbot = (CheckBox) findViewById(R.id.cbOrbot);
 		CheckBox color = (CheckBox) findViewById(R.id.cbColorMode);
 
 		images.setChecked(imagesBool);
@@ -105,12 +115,11 @@ public class SettingsActivity extends ThemableSettingsActivity {
 			flash.setChecked(false);
 		}
 		adblock.setChecked(mPreferences.getAdBlockEnabled());
-		orbot.setChecked(mPreferences.getUseProxy());
 		color.setChecked(mPreferences.getColorModeEnabled());
 
-		initCheckBox(flash, adblock, images, enablejs, orbot, color);
+		initCheckBox(flash, adblock, images, enablejs, color);
 		clickListenerForCheckBoxes(layoutFlash, layoutBlockAds, layoutImages, layoutEnableJS,
-				layoutOrbot, layoutColor, flash, adblock, images, enablejs, orbot, color);
+				layoutProxyChoice, layoutColor, flash, adblock, images, enablejs, color);
 
 		RelativeLayout general = (RelativeLayout) findViewById(R.id.layoutGeneral);
 		RelativeLayout display = (RelativeLayout) findViewById(R.id.layoutDisplay);
@@ -127,9 +136,9 @@ public class SettingsActivity extends ThemableSettingsActivity {
 
 	public void clickListenerForCheckBoxes(RelativeLayout layoutFlash,
 			RelativeLayout layoutBlockAds, RelativeLayout layoutImages,
-			RelativeLayout layoutEnableJS, RelativeLayout layoutOrbot, RelativeLayout layoutColor,
+			RelativeLayout layoutEnableJS, LinearLayout layoutProxyChoice, RelativeLayout layoutColor,
 			final CheckBox flash, final CheckBox adblock, final CheckBox images,
-			final CheckBox enablejs, final CheckBox orbot, final CheckBox color) {
+			final CheckBox enablejs, final CheckBox color) {
 		layoutFlash.setOnClickListener(new OnClickListener() {
 
 			@Override
@@ -168,17 +177,12 @@ public class SettingsActivity extends ThemableSettingsActivity {
 			}
 
 		});
-		layoutOrbot.setOnClickListener(new OnClickListener() {
+		layoutProxyChoice.setOnClickListener(new OnClickListener() {
 
 			@Override
-			public void onClick(View v) {
-				if (orbot.isEnabled()) {
-					orbot.setChecked(!orbot.isChecked());
-				} else {
-					Utils.showToast(mContext, getResources().getString(R.string.install_orbot));
-				}
+			public void onClick(View view) {
+				proxyChoicePicker();
 			}
-
 		});
 		layoutColor.setOnClickListener(new OnClickListener() {
 
@@ -191,7 +195,7 @@ public class SettingsActivity extends ThemableSettingsActivity {
 	}
 
 	public void initCheckBox(CheckBox flash, CheckBox adblock, CheckBox images, CheckBox enablejs,
-			CheckBox orbot, CheckBox color) {
+			CheckBox color) {
 		flash.setEnabled(API < 19);
 		flash.setOnCheckedChangeListener(new OnCheckedChangeListener() {
 
@@ -253,20 +257,7 @@ public class SettingsActivity extends ThemableSettingsActivity {
 			}
 
 		});
-		OrbotHelper oh = new OrbotHelper(this);
-		if (!oh.isOrbotInstalled()) {
-			orbot.setEnabled(false);
-		}
 
-		orbot.setOnCheckedChangeListener(new OnCheckedChangeListener() {
-
-			@Override
-			public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-				mPreferences.setUseProxy(isChecked);
-
-			}
-
-		});
 		color.setOnCheckedChangeListener(new OnCheckedChangeListener() {
 
 			@Override
@@ -307,6 +298,51 @@ public class SettingsActivity extends ThemableSettingsActivity {
 				});
 		AlertDialog alert = builder.create();
 		alert.show();
+	}
+
+	private void proxyChoicePicker() {
+		AlertDialog.Builder picker = new AlertDialog.Builder(mContext);
+		picker.setTitle(getResources().getString(R.string.http_proxy));
+		picker.setSingleChoiceItems(mProxyChoices, mPreferences.getProxyChoice(),
+				new DialogInterface.OnClickListener() {
+
+			@Override
+			public void onClick(DialogInterface dialog, int which) {
+				setProxyChoice(which);
+			}
+		});
+		picker.setNeutralButton(getResources().getString(R.string.action_ok),
+				new DialogInterface.OnClickListener() {
+					@Override
+					public void onClick(DialogInterface dialog, int which) {
+					}
+				});
+		picker.show();
+	}
+
+	private void setProxyChoice(int choice) {
+		switch (choice) {
+			case 1:
+				OrbotHelper oh = new OrbotHelper(this);
+				if (!oh.isOrbotInstalled()) {
+					choice = 0;
+					Utils.showToast(mContext, getResources().getString(R.string.install_orbot));
+				}
+				break;
+
+			case 2:
+				I2PAndroidHelper ih = new I2PAndroidHelper(this);
+				if (!ih.isI2PAndroidInstalled()) {
+					choice = 0;
+					ih.promptToInstall(this);
+				}
+				break;
+		}
+
+		mPreferences.setUseProxy(choice != 0);
+		mPreferences.setProxyChoice(choice);
+		if (choice < mProxyChoices.length)
+			mProxyChoiceName.setText(mProxyChoices[choice]);
 	}
 
 	public void agentPicker() {

--- a/app/src/main/java/acr/browser/lightning/constant/Constants.java
+++ b/app/src/main/java/acr/browser/lightning/constant/Constants.java
@@ -38,4 +38,9 @@ public final class Constants {
 	public static final String FILE = "file://";
 	public static final String FOLDER = "folder://";
 	public static final String TAG = "Lightning";
+
+	// These should match the order of @array/proxy_choices_array
+	public static final int NO_PROXY = 0;
+	public static final int PROXY_ORBOT = 1;
+	public static final int PROXY_I2P = 2;
 }

--- a/app/src/main/java/acr/browser/lightning/constant/Constants.java
+++ b/app/src/main/java/acr/browser/lightning/constant/Constants.java
@@ -43,4 +43,5 @@ public final class Constants {
 	public static final int NO_PROXY = 0;
 	public static final int PROXY_ORBOT = 1;
 	public static final int PROXY_I2P = 2;
+	public static final int PROXY_MANUAL = 3;
 }

--- a/app/src/main/java/acr/browser/lightning/controller/BrowserController.java
+++ b/app/src/main/java/acr/browser/lightning/controller/BrowserController.java
@@ -54,5 +54,7 @@ public interface BrowserController {
 
 	boolean isIncognito();
 
+	boolean isProxyReady();
+
 	int getMenu();
 }

--- a/app/src/main/java/acr/browser/lightning/preference/PreferenceManager.java
+++ b/app/src/main/java/acr/browser/lightning/preference/PreferenceManager.java
@@ -233,7 +233,7 @@ public class PreferenceManager {
 	}
 
 	public int getProxyChoice() {
-		return mPrefs.getInt(Name.PROXY_CHOICE, 0);
+		return mPrefs.getInt(Name.PROXY_CHOICE, Constants.NO_PROXY);
 	}
 
 	public int getUserAgentChoice() {
@@ -409,12 +409,17 @@ public class PreferenceManager {
 	}
 
 	/**
-	 * 0: None. 1: Orbot. 2: I2P.
+	 * Valid choices:
+	 * <ul>
+	 *     <li>{@link Constants#NO_PROXY}</li>
+	 *     <li>{@link Constants#PROXY_ORBOT}</li>
+	 *     <li>{@link Constants#PROXY_I2P}</li>
+	 * </ul>
 	 *
 	 * @param choice the proxy to use.
 	 */
 	public void setProxyChoice(int choice) {
-		putBoolean(Name.USE_PROXY, choice != 0);
+		putBoolean(Name.USE_PROXY, choice != Constants.NO_PROXY);
 		putInt(Name.PROXY_CHOICE, choice);
 	}
 

--- a/app/src/main/java/acr/browser/lightning/preference/PreferenceManager.java
+++ b/app/src/main/java/acr/browser/lightning/preference/PreferenceManager.java
@@ -49,6 +49,7 @@ public class PreferenceManager {
 		public static final String DEFAULT_BOOKMARKS = "defaultBookmarks";
 
 		public static final String USE_PROXY = "useProxy";
+		public static final String PROXY_CHOICE = "proxyChoice";
 		public static final String USE_PROXY_HOST = "useProxyHost";
 		public static final String USE_PROXY_PORT = "useProxyPort";
 		public static final String INITIAL_CHECK_FOR_TOR = "checkForTor";
@@ -226,6 +227,10 @@ public class PreferenceManager {
 		return mPrefs.getBoolean(Name.USE_PROXY, false);
 	}
 
+	public int getProxyChoice() {
+		return mPrefs.getInt(Name.PROXY_CHOICE, 0);
+	}
+
 	public int getUserAgentChoice() {
 		return mPrefs.getInt(Name.USER_AGENT, 1);
 	}
@@ -396,6 +401,10 @@ public class PreferenceManager {
 
 	public void setUseProxy(boolean enable) {
 		putBoolean(Name.USE_PROXY, enable);
+	}
+
+	public void setProxyChoice(int choice) {
+		putInt(Name.PROXY_CHOICE, choice);
 	}
 
 	public void setUserAgentChoice(int choice) {

--- a/app/src/main/java/acr/browser/lightning/preference/PreferenceManager.java
+++ b/app/src/main/java/acr/browser/lightning/preference/PreferenceManager.java
@@ -53,6 +53,7 @@ public class PreferenceManager {
 		public static final String USE_PROXY_HOST = "useProxyHost";
 		public static final String USE_PROXY_PORT = "useProxyPort";
 		public static final String INITIAL_CHECK_FOR_TOR = "checkForTor";
+		public static final String INITIAL_CHECK_FOR_I2P = "checkForI2P";
 	}
 
 	private static PreferenceManager mInstance;
@@ -85,6 +86,10 @@ public class PreferenceManager {
 
 	public boolean getCheckedForTor() {
 		return mPrefs.getBoolean(Name.INITIAL_CHECK_FOR_TOR, false);
+	}
+
+	public boolean getCheckedForI2P() {
+		return mPrefs.getBoolean(Name.INITIAL_CHECK_FOR_I2P, false);
 	}
 
 	public boolean getClearCacheExit() {
@@ -271,6 +276,10 @@ public class PreferenceManager {
 		putBoolean(Name.INITIAL_CHECK_FOR_TOR, check);
 	}
 
+	public void setCheckedForI2P(boolean check) {
+		putBoolean(Name.INITIAL_CHECK_FOR_I2P, check);
+	}
+
 	public void setClearCacheExit(boolean enable) {
 		putBoolean(Name.CLEAR_CACHE_EXIT, enable);
 	}
@@ -399,11 +408,13 @@ public class PreferenceManager {
 		putBoolean(Name.DARK_THEME, use);
 	}
 
-	public void setUseProxy(boolean enable) {
-		putBoolean(Name.USE_PROXY, enable);
-	}
-
+	/**
+	 * 0: None. 1: Orbot. 2: I2P.
+	 *
+	 * @param choice the proxy to use.
+	 */
 	public void setProxyChoice(int choice) {
+		putBoolean(Name.USE_PROXY, choice != 0);
 		putInt(Name.PROXY_CHOICE, choice);
 	}
 

--- a/app/src/main/java/acr/browser/lightning/preference/PreferenceManager.java
+++ b/app/src/main/java/acr/browser/lightning/preference/PreferenceManager.java
@@ -423,6 +423,14 @@ public class PreferenceManager {
 		putInt(Name.PROXY_CHOICE, choice);
 	}
 
+	public void setProxyHost(String proxyHost) {
+		putString(Name.USE_PROXY_HOST, proxyHost);
+	}
+
+	public void setProxyPort(int proxyPort) {
+		putInt(Name.USE_PROXY_PORT, proxyPort);
+	}
+
 	public void setUserAgentChoice(int choice) {
 		putInt(Name.USER_AGENT, choice);
 	}

--- a/app/src/main/java/acr/browser/lightning/view/LightningView.java
+++ b/app/src/main/java/acr/browser/lightning/view/LightningView.java
@@ -526,6 +526,12 @@ public class LightningView {
 	}
 
 	public synchronized void reload() {
+		// Check if configured proxy is available
+		if (!mBrowserController.isProxyReady()) {
+			// User has been notified
+			return;
+		}
+
 		if (mWebView != null) {
 			mWebView.reload();
 		}
@@ -611,6 +617,12 @@ public class LightningView {
 	}
 
 	public synchronized void loadUrl(String url) {
+		// Check if configured proxy is available
+		if (!mBrowserController.isProxyReady()) {
+			// User has been notified
+			return;
+		}
+
 		if (mWebView != null) {
 			mWebView.loadUrl(url);
 		}
@@ -815,6 +827,12 @@ public class LightningView {
 
 		@Override
 		public boolean shouldOverrideUrlLoading(WebView view, String url) {
+			// Check if configured proxy is available
+			if (!mBrowserController.isProxyReady()) {
+				// User has been notified
+				return true;
+			}
+
 			if (mBrowserController.isIncognito()) {
 				return super.shouldOverrideUrlLoading(view, url);
 			}

--- a/app/src/main/res/layout/picker_manual_proxy.xml
+++ b/app/src/main/res/layout/picker_manual_proxy.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical"
+              android:paddingLeft="4dp"
+              android:paddingStart="4dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/host"/>
+
+        <EditText
+            android:id="@+id/proxyHost"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:inputType="text"/>
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/port"/>
+
+        <EditText
+            android:id="@+id/proxyPort"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:inputType="number"/>
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical" >
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical">
 
     <include layout="@layout/toolbar_settings" />
 
@@ -159,33 +160,32 @@
                 android:layout_marginRight="10dp"
                 android:background="?attr/dividerColor" />
 
-            <RelativeLayout
-                android:id="@+id/layoutUseOrbot"
+            <LinearLayout
+                android:id="@+id/layoutProxyChoice"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="?attr/listChoiceBackgroundIndicator"
                 android:minHeight="60dp"
+                android:orientation="vertical"
                 android:paddingBottom="10dp"
-                android:paddingRight="10dp"
                 android:paddingTop="10dp" >
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_alignParentLeft="true"
-                    android:layout_centerVertical="true"
                     android:paddingLeft="16dp"
-                    android:paddingRight="60dp"
-                    android:text="@string/enable_orbot"
+                    android:text="@string/http_proxy"
                     android:textAppearance="?android:attr/textAppearanceMedium" />
 
-                <CheckBox
-                    android:id="@+id/cbOrbot"
+                <TextView
+                    android:id="@+id/proxyChoiceName"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_alignParentRight="true"
-                    android:layout_centerVertical="true" />
-            </RelativeLayout>
+                    android:paddingLeft="16dp"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textColor="@color/light"
+                    tools:text="Disabled" />
+            </LinearLayout>
             
             <LinearLayout
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,7 +158,12 @@
     <string name="powered_by_google">Powered by Google</string>
     <string name="title_adblock">AdBlock</string>
     <string name="message_adblock">AdBlock is currently only available in the browser\'s paid version, Lightning Browser+. It is available to download on Google Play.</string>
-    <string name="enable_orbot">Enable Orbot</string>
+    <string name="http_proxy">HTTP proxy</string>
+    <string-array name="proxy_choices_array">
+        <item>None</item>
+        <item>Orbot</item>
+        <item>I2P</item>
+    </string-array>
     <string name="use_tor_prompt">It looks like you have Orbot installed. Do you want to use Tor?</string>
     <string name="install_orbot">Please install Orbot in order to proxy with Tor.</string>
     <string name="yes">Yes</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,7 +163,11 @@
         <item>None</item>
         <item>Orbot</item>
         <item>I2P</item>
+        <item>Manual</item>
     </string-array>
+    <string name="manual_proxy">Manual proxy</string>
+    <string name="host">Host:</string>
+    <string name="port">Port:</string>
     <string name="use_tor_prompt">It looks like you have Orbot installed. Do you want to use Tor?</string>
     <string name="use_i2p_prompt">It looks like you have I2P installed. Do you want to use I2P?</string>
     <string name="install_orbot">Please install Orbot in order to proxy with Tor.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,6 +167,8 @@
     <string name="use_tor_prompt">It looks like you have Orbot installed. Do you want to use Tor?</string>
     <string name="use_i2p_prompt">It looks like you have I2P installed. Do you want to use I2P?</string>
     <string name="install_orbot">Please install Orbot in order to proxy with Tor.</string>
+    <string name="i2p_not_running">I2P is not running.</string>
+    <string name="i2p_tunnels_not_ready">I2P tunnels are not ready yet.</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="clear_cookies_exit">Clear cookies on exit</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -165,6 +165,7 @@
         <item>I2P</item>
     </string-array>
     <string name="use_tor_prompt">It looks like you have Orbot installed. Do you want to use Tor?</string>
+    <string name="use_i2p_prompt">It looks like you have I2P installed. Do you want to use I2P?</string>
     <string name="install_orbot">Please install Orbot in order to proxy with Tor.</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>


### PR DESCRIPTION
This PR adds support for I2P alongside Orbot, and refactors the relevant code to make adding other apps easier in future.

It does require the I2P client library v0.7, which will be released in a week or so.

If desired, I can add a "Manual" option for users to manually enter the details of an HTTP proxy. I am not sure how you would want that presented in the settings menu.

I can also revert the import changes in `BrowserActivity` if desired, but I wouldn't do it until the PR is about to merge, because it is being auto-managed by Android Studio.