### PR TITLE
allow "panic button" apps to close Lightning

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -104,6 +104,11 @@
                 <data android:scheme="http"/>
                 <data android:scheme="https"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="info.guardianproject.panic.action.TRIGGER" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".activity.SettingsActivity"

--- a/app/src/main/java/acr/browser/lightning/activity/BrowserActivity.java
+++ b/app/src/main/java/acr/browser/lightning/activity/BrowserActivity.java
@@ -925,6 +925,12 @@ public abstract class BrowserActivity extends ThemableBrowserActivity implements
     }
 
     void handleNewIntent(Intent intent) {
+        final String PANIC_TRIGGER_ACTION = "info.guardianproject.panic.action.TRIGGER";
+        if (intent != null && PANIC_TRIGGER_ACTION.equals(intent.getAction())) {
+            closeBrowser();
+            return;
+        }
+
         final String url;
         if (intent != null) {
             url = intent.getDataString();


### PR DESCRIPTION
PanicKit provides a common framework for creating "panic button" apps that can trigger actions in "panic responder" apps.  In this case, the response is to close the app.  That way, if the user has configured various things to be cleared when the app closes, pressing the panic button will make all
those things be cleared.

We've been developing "panic button" features in our apps for years, and now we are working to make a more flexible and open ecosystem of apps that can both trigger other apps, or respond to triggers. This setup allows for easy configuration of a single trigger action which can then trigger multiple apps.

More info on the panic kit work here:
https://dev.guardianproject.info/projects/panic/wiki
https://github.com/guardianproject/panickit

The first panic button app that sends this kind of trigger is called Ripple, and it is available here:
https://github.com/guardianproject/ripple
https://play.google.com/store/apps/details?id=info.guardianproject.ripple
https://guardianproject.info/fdroid

I'm adding support to this app right now:
https://panicbutton.io/
https://play.google.com/store/apps/details?id=org.iilab.pb

This is all code that I wrote, and you can have it under any license you want, including public domain. I waive all my copyright claims to it.
