### PR TITLE
Remove package name from X-Requested-With header

### DIFF
--- a/app/src/main/java/acr/browser/lightning/app/BrowserApp.java
+++ b/app/src/main/java/acr/browser/lightning/app/BrowserApp.java
@@ -51,4 +51,18 @@ public class BrowserApp extends Application {
         return get(context).mBus;
     }
 
+    @Override
+    public String getPackageName() {
+        try {
+            throw new Exception();
+        } catch (Exception e){
+            StackTraceElement[] elements = e.getStackTrace();
+            for (StackTraceElement element: elements) {
+                if(element.getClassName().startsWith("android.webkit.")){
+                    return null;
+                }
+            }
+        }
+        return super.getPackageName();
+    }
 }


### PR DESCRIPTION
Returns null when webview queries getPackageName from
getApplicationContext(), which will make it set header blank or remove it.
