### PR TITLE
Add Handover Tapless support

### DIFF
--- a/app/src/main/java/acr/browser/lightning/activity/BrowserActivity.java
+++ b/app/src/main/java/acr/browser/lightning/activity/BrowserActivity.java
@@ -1344,6 +1344,13 @@ public abstract class BrowserActivity extends ThemableBrowserActivity implements
         if (url == null || mSearch == null || mSearch.hasFocus()) {
             return;
         }
+        // Send to Handover
+        Intent i = new Intent("com.hamzahrmalik.handover.android.SEND");
+        // Put the data in using the tag
+        i.putExtra("**URL**=", url);
+        // Send broadcast
+        sendBroadcast(i);
+
         final LightningView currentTab = mTabsManager.getCurrentTab();
         mEventBus.post(new BrowserEvents.CurrentPageUrl(url));
         if (shortUrl && !UrlUtils.isSpecialUrl(url)) {


### PR DESCRIPTION
Handover is an app which seamlessly allows the user to open content from their phone on their PC
Adding Handover Tapless means this app can support that
More info: http://forum.xda-developers.com/android/apps-games/handover-seamlessly-tasks-phone-to-pc-t3365521
If this is merged into the release, please let me know and I'd add Lightning as a supported browser in the Handover app
