### PR TITLE
Fix intent being ignored when intent initialises app and tab restoration is off

### DIFF
--- a/app/src/main/java/acr/browser/lightning/activity/TabsManager.java
+++ b/app/src/main/java/acr/browser/lightning/activity/TabsManager.java
@@ -130,7 +130,7 @@ public class TabsManager {
                 if (mPreferenceManager.getRestoreLostTabsEnabled()) {
                     restoreLostTabs(url, activity, subscriber);
                 } else {
-                    newTab(activity, null, false);
+                    newTab(activity, url, false);
                     finishInitialization();
                     subscriber.onComplete();
                 }


### PR DESCRIPTION
To reproduce, turn off tab restoration, close the app from recents or otherwise force it to have to reinitialise upon the next intent, and open a link from another app.
