### PR TITLE
Added Basic Keyboard Shortcut Support

### DIFF
--- a/app/src/main/java/acr/browser/lightning/activity/BrowserActivity.java
+++ b/app/src/main/java/acr/browser/lightning/activity/BrowserActivity.java
@@ -713,6 +713,50 @@ public abstract class BrowserActivity extends ThemableBrowserActivity implements
     }
 
     @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        // Keyboard shortcuts
+        if (event.isCtrlPressed() && event.getAction() == KeyEvent.ACTION_DOWN) {
+            switch(event.getKeyCode()) {
+                case KeyEvent.KEYCODE_T:
+                    // Open new tab
+                    newTab(null, true);
+                    return true;
+                case KeyEvent.KEYCODE_W:
+                    // Close current tab
+                    mPresenter.deleteTab(mTabsManager.indexOfCurrentTab());
+                    return true;
+                case KeyEvent.KEYCODE_Q:
+                    // Close browser
+                    closeBrowser();
+                    return true;
+                case KeyEvent.KEYCODE_R:
+                    // Refresh current tab
+                    mTabsManager.getCurrentTab().reload();
+                    return true;
+                case KeyEvent.KEYCODE_TAB:
+                    int nextIndex = 0;
+                    if(event.isShiftPressed()) {
+                        // Go back one tab
+                        if(mTabsManager.indexOfCurrentTab() > 0) nextIndex = mTabsManager.indexOfCurrentTab() - 1;
+                        else nextIndex = mTabsManager.last();
+                    } else {
+                        // Go forward one tab
+                        if(mTabsManager.indexOfCurrentTab() < mTabsManager.last()) nextIndex = mTabsManager.indexOfCurrentTab() + 1;
+                        else nextIndex = 0;
+                    }
+                    mPresenter.tabChanged(nextIndex);
+                    return true;
+            }
+        } else if(event.getAction() == KeyEvent.ACTION_DOWN && event.getKeyCode() == KeyEvent.KEYCODE_SEARCH) {
+            // Highlight search field
+            mSearch.requestFocus();
+            mSearch.selectAll();
+            return true;
+        }
+        return super.dispatchKeyEvent(event);
+    }
+
+    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         final LightningView currentView = mTabsManager.getCurrentTab();
         final String currentUrl = currentView != null ? currentView.getUrl() : null;


### PR DESCRIPTION
The following shortcuts were added:

Ctrl+t - Open a new tab
Ctrl+w - Closes the current tab
Ctrl+r - Reloads the current tab
Ctrl+q - Closes the browser
Ctrl+Tab - Switch to next tab
Ctrl+Shift+Tab - Switch to previous tab
Search - Highlights the URL bar

Implemented in dispatchKeyEvent().  Tested on an ASUS TF300T convertible tablet.