### PR TITLE
Show realm in HTTP auth dialog

### DIFF
--- a/app/src/main/java/acr/browser/lightning/view/LightningWebClient.java
+++ b/app/src/main/java/acr/browser/lightning/view/LightningWebClient.java
@@ -26,6 +26,7 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.EditText;
 import android.widget.LinearLayout;
+import android.widget.TextView;
 
 import java.io.ByteArrayInputStream;
 import java.net.URISyntaxException;
@@ -125,11 +126,14 @@ public class LightningWebClient extends WebViewClient {
                                           final String host, final String realm) {
 
         AlertDialog.Builder builder = new AlertDialog.Builder(mActivity);
+        final TextView realmLabel = new TextView(mActivity);
         final EditText name = new EditText(mActivity);
         final EditText password = new EditText(mActivity);
         LinearLayout passLayout = new LinearLayout(mActivity);
         passLayout.setOrientation(LinearLayout.VERTICAL);
+        realmLabel.setText(mActivity.getString(R.string.label_realm, realm));
 
+        passLayout.addView(realmLabel);
         passLayout.addView(name);
         passLayout.addView(password);
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,6 +142,7 @@
     <string name="action_allow">Allow</string>
     <string name="action_dont_allow">Don\'t Allow</string>
     <string name="title_sign_in">Sign In</string>
+    <string name="label_realm">Server message: %s</string>
     <string name="hint_username">Username</string>
     <string name="hint_password">Password</string>
     <string name="search_suggestions">Search Suggestions</string>


### PR DESCRIPTION
Display realm when an HTTP authentication is requested.

The term "Server message" is used instead of realm as not all users would understand what realm means.