### PR TITLE
Prevent URL-box resetting on cursor movement

### DIFF
--- a/app/src/main/java/acr/browser/lightning/activity/BrowserActivity.java
+++ b/app/src/main/java/acr/browser/lightning/activity/BrowserActivity.java
@@ -550,10 +550,10 @@ public abstract class BrowserActivity extends ThemableBrowserActivity implements
                 return;
             }
             String url = currentView.getUrl();
-            if (UrlUtils.isSpecialUrl(url)) {
-                mSearch.setText("");
-            } else {
-                mSearch.setText(url);
+            if (!UrlUtils.isSpecialUrl(url)) {
+                if (!mSearch.hasFocus()) {
+                    mSearch.setText(url);
+                }
             }
         }
     }


### PR DESCRIPTION
Stop the URL-box from resetting to the current URL (or blank) whenever the user clicks on it to move the cursor.

If the user clicks on the URL-box to change the cursor position while they are typing into it, it will reset to the page's current URL, or if it is at the bookmarks page or other page with blank URL-box.

This commit stops that happening.