### PR TITLE
Removed erroneous addPreferencesFromResources call

### DIFF
--- a/app/src/main/java/acr/browser/lightning/settings/fragment/DebugSettingsFragment.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/fragment/DebugSettingsFragment.kt
@@ -16,7 +16,6 @@ class DebugSettingsFragment : AbstractSettingsFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         BrowserApp.appComponent.inject(this)
-        addPreferencesFromResource(R.xml.preference_debug)
 
         togglePreference(
                 preference = LEAK_CANARY,


### PR DESCRIPTION
addPreferencesFromResource is already called off of the onCreate of AbstractSettingsFragment.kt.
This was causing a duplicate, seemingly non-functional "LeakCanary" option to appear in the Debug settings.

Removing the extraneous addPreferencesFromResource method call on DebugSettingsFragment.kt resolved this issue.