### PR TITLE
Creating TabInitializer visitor to standardize initial URL loading

### DIFF
--- a/app/src/main/java/acr/browser/lightning/browser/BrowserPresenter.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/BrowserPresenter.kt
@@ -14,6 +14,8 @@ import acr.browser.lightning.preference.UserPreferences
 import acr.browser.lightning.ssl.SSLState
 import acr.browser.lightning.utils.UrlUtils
 import acr.browser.lightning.view.LightningView
+import acr.browser.lightning.view.TabInitializer
+import acr.browser.lightning.view.UrlInitializer
 import android.app.Activity
 import android.app.Application
 import android.content.Intent
@@ -216,12 +218,12 @@ class BrowserPresenter(private val view: BrowserView, private val isIncognito: B
         } else if (url != null) {
             if (URLUtil.isFileUrl(url)) {
                 view.showBlockedLocalFileDialog {
-                    newTab(url, true)
+                    newTab(UrlInitializer(url), true)
                     shouldClose = true
                     tabsModel.lastTab()?.isNewTab = true
                 }
             } else {
-                newTab(url, true)
+                newTab(UrlInitializer(url), true)
                 shouldClose = true
                 tabsModel.lastTab()?.isNewTab = true
             }
@@ -267,11 +269,11 @@ class BrowserPresenter(private val view: BrowserView, private val isIncognito: B
      * Open a new tab with the specified URL. You can choose to show the tab or load it in the
      * background.
      *
-     * @param url  the URL to load, may be null if you don't wish to load anything.
+     * @param tabInitializer the tab initializer to run after the tab as been created.
      * @param show whether or not to switch to this tab after opening it.
      * @return true if we successfully created the tab, false if we have hit max tabs.
      */
-    fun newTab(url: String?, show: Boolean): Boolean {
+    fun newTab(tabInitializer: TabInitializer, show: Boolean): Boolean {
         // Limit number of tabs for limited version of app
         if (!BuildConfig.FULL_VERSION && tabsModel.size() >= 10) {
             view.showSnackbar(R.string.max_tabs)
@@ -280,7 +282,7 @@ class BrowserPresenter(private val view: BrowserView, private val isIncognito: B
 
         Log.d(TAG, "New tab, show: $show")
 
-        val startingTab = tabsModel.newTab(view as Activity, url, isIncognito)
+        val startingTab = tabsModel.newTab(view as Activity, tabInitializer, isIncognito)
         if (tabsModel.size() == 1) {
             startingTab.resumeTimers()
         }

--- a/app/src/main/java/acr/browser/lightning/browser/activity/BrowserActivity.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/activity/BrowserActivity.kt
@@ -1764,7 +1764,7 @@ abstract class BrowserActivity : ThemableBrowserActivity(), BrowserView, UIContr
      * the newly created WebView.
      */
     override fun onCreateWindow(resultMsg: Message) {
-        presenter?.newTab(ResultMsgInitializer(resultMsg), true)
+        presenter?.newTab(ResultMessageInitializer(resultMsg), true)
     }
 
     /**

--- a/app/src/main/java/acr/browser/lightning/di/AppModule.kt
+++ b/app/src/main/java/acr/browser/lightning/di/AppModule.kt
@@ -16,6 +16,7 @@ import android.view.inputmethod.InputMethodManager
 import dagger.Module
 import dagger.Provides
 import io.reactivex.Scheduler
+import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import net.i2p.android.ui.I2PAndroidHelper
 import java.util.concurrent.Executors
@@ -78,6 +79,11 @@ class AppModule(private val browserApp: BrowserApp) {
     @Named("network")
     @Singleton
     fun providesNetworkThread(): Scheduler = Schedulers.from(ThreadPoolExecutor(0, 4, 60, TimeUnit.SECONDS, LinkedBlockingDeque()))
+
+    @Provides
+    @Named("main")
+    @Singleton
+    fun providesMainThread(): Scheduler = AndroidSchedulers.mainThread()
 
     @Provides
     @Singleton

--- a/app/src/main/java/acr/browser/lightning/view/LightningView.kt
+++ b/app/src/main/java/acr/browser/lightning/view/LightningView.kt
@@ -51,7 +51,7 @@ import javax.inject.Named
  */
 class LightningView(
     private val activity: Activity,
-    url: String?,
+    tabInitializer: TabInitializer,
     val isIncognito: Boolean
 ) {
 
@@ -204,15 +204,7 @@ class LightningView(
         initializeSettings()
         initializePreferences(activity)
 
-        if (url != null) {
-            if (!url.isBlank()) {
-                tab.loadUrl(url, requestHeaders)
-            } else {
-                // don't load anything, the user is looking for a blank tab
-            }
-        } else {
-            loadHomePage()
-        }
+        tabInitializer.initialize(tab)
     }
 
     fun currentSslState(): SSLState = lightningWebClient.sslState

--- a/app/src/main/java/acr/browser/lightning/view/TabInitializer.kt
+++ b/app/src/main/java/acr/browser/lightning/view/TabInitializer.kt
@@ -117,7 +117,7 @@ class AsyncUrlInitializer(
  * An initializer that sets the [WebView] as the target of the [resultMessage]. Used for
  * `target="_blank"` links.
  */
-class ResultMsgInitializer(private val resultMessage: Message) : TabInitializer {
+class ResultMessageInitializer(private val resultMessage: Message) : TabInitializer {
 
     override fun initialize(webView: WebView) {
         resultMessage.apply {

--- a/app/src/main/java/acr/browser/lightning/view/TabInitializer.kt
+++ b/app/src/main/java/acr/browser/lightning/view/TabInitializer.kt
@@ -1,0 +1,148 @@
+package acr.browser.lightning.view
+
+import acr.browser.lightning.constant.SCHEME_BOOKMARKS
+import acr.browser.lightning.constant.SCHEME_HOMEPAGE
+import acr.browser.lightning.html.bookmark.BookmarkPage
+import acr.browser.lightning.html.homepage.StartPage
+import acr.browser.lightning.preference.UserPreferences
+import android.app.Activity
+import android.os.Bundle
+import android.os.Message
+import android.webkit.WebView
+import io.reactivex.Scheduler
+import io.reactivex.Single
+import io.reactivex.rxkotlin.subscribeBy
+
+/**
+ * An initializer that is run on a [LightningView] after it is created.
+ */
+interface TabInitializer {
+
+    /**
+     * Initialize the [WebView] instance held by the [LightningView].
+     */
+    fun initialize(webView: WebView)
+
+}
+
+/**
+ * An initializer that loads a [url].
+ */
+class UrlInitializer(private val url: String) : TabInitializer {
+
+    override fun initialize(webView: WebView) {
+        webView.loadUrl(url)
+    }
+
+}
+
+/**
+ * An initializer that displays the page set as the user's homepage preference.
+ */
+class HomePageInitializer(
+    private val userPreferences: UserPreferences,
+    private val activity: Activity,
+    private val databaseScheduler: Scheduler,
+    private val foregroundScheduler: Scheduler
+) : TabInitializer {
+
+    override fun initialize(webView: WebView) {
+        val homepage = userPreferences.homepage
+
+        when (homepage) {
+            SCHEME_HOMEPAGE -> StartPageInitializer(databaseScheduler, foregroundScheduler)
+            SCHEME_BOOKMARKS -> BookmarkPageInitializer(activity, databaseScheduler, foregroundScheduler)
+            else -> UrlInitializer(homepage)
+        }.initialize(webView)
+    }
+
+}
+
+/**
+ * An initializer that displays the start page.
+ */
+class StartPageInitializer(
+    private val databaseScheduler: Scheduler,
+    private val foregroundScheduler: Scheduler
+) : TabInitializer {
+
+    override fun initialize(webView: WebView) {
+        StartPage()
+            .createHomePage()
+            .subscribeOn(databaseScheduler)
+            .observeOn(foregroundScheduler)
+            .subscribeBy(onSuccess = webView::loadUrl)
+    }
+
+}
+
+/**
+ * An initializer that displays the bookmark page.
+ */
+class BookmarkPageInitializer(
+    private val activity: Activity,
+    private val databaseScheduler: Scheduler,
+    private val foregroundScheduler: Scheduler
+) : TabInitializer {
+
+    override fun initialize(webView: WebView) {
+        BookmarkPage(activity)
+            .createBookmarkPage()
+            .subscribeOn(databaseScheduler)
+            .observeOn(foregroundScheduler)
+            .subscribeBy(onSuccess = webView::loadUrl)
+    }
+
+}
+
+/**
+ * An initializer that loads the url emitted by the [asyncUrl] observable.
+ */
+class AsyncUrlInitializer(
+    private val asyncUrl: Single<String>,
+    private val backgroundScheduler: Scheduler,
+    private val foregroundScheduler: Scheduler
+) : TabInitializer {
+
+    override fun initialize(webView: WebView) {
+        asyncUrl
+            .subscribeOn(backgroundScheduler)
+            .observeOn(foregroundScheduler)
+            .subscribeBy(onSuccess = webView::loadUrl)
+    }
+
+}
+
+/**
+ * An initializer that sets the [WebView] as the target of the [resultMessage]. Used for
+ * `target="_blank"` links.
+ */
+class ResultMsgInitializer(private val resultMessage: Message) : TabInitializer {
+
+    override fun initialize(webView: WebView) {
+        resultMessage.apply {
+            (obj as WebView.WebViewTransport).webView = webView
+        }.sendToTarget()
+    }
+
+}
+
+/**
+ * An initializer that restores the [WebView] state using the [bundle].
+ */
+class BundleInitializer(private val bundle: Bundle) : TabInitializer {
+
+    override fun initialize(webView: WebView) {
+        webView.restoreState(bundle)
+    }
+
+}
+
+/**
+ * An initializer that does not load anything into the [WebView].
+ */
+class NoOpInitializer : TabInitializer {
+
+    override fun initialize(webView: WebView) = Unit
+
+}


### PR DESCRIPTION
# Summary
The logic dictating the initial URL loaded by a `LightningView` originally was a combination of external logic and internal logic that followed the following pattern:
- `null` - home page preference was loaded.
- `"url"` - url was loaded.
- `""` - nothing was loaded, it was up to external consumers to load something later.

This was pretty flexible, but it was not readable at all as there was no indication to a consumer that passing `null` would result in the homepage being loaded, but passing an empty string would result in nothing being loaded at start. Therefore, this system introduced in this PR was created where a visitor is now injected into the `LightningView` in place of the `url: String`.

This visitor is called a `TabInitializer` and there are several variants right now.
- `UrlInitializer`: loads a url after load.
- `HomePageInitializer`: loads the user's home page preference.
- `StartPageInitializer`: loads the start page.
- `BookmarkPageInitializer`: loads the bookmark page.
- `AsyncUrlInitializer`: loads the url emitted by an `rx.Single`.
- `ResultMessageInitializer`: sets the `WebView` as the target of a `Message`.
- `BundleInitializer`: restores the `WebView` from a `Bundle`.
- `NoOpInitializer`: doesn't do anything to the `WebView`.

This allows more clarity in the various ways that `LightningViews` were initialized.