### PR TITLE
TabManager refactor

### DIFF
--- a/app/src/main/java/acr/browser/lightning/BrowserApp.kt
+++ b/app/src/main/java/acr/browser/lightning/BrowserApp.kt
@@ -5,6 +5,7 @@ import acr.browser.lightning.database.bookmark.BookmarkRepository
 import acr.browser.lightning.di.AppComponent
 import acr.browser.lightning.di.AppModule
 import acr.browser.lightning.di.DaggerAppComponent
+import acr.browser.lightning.di.DatabaseScheduler
 import acr.browser.lightning.preference.DeveloperPreferences
 import acr.browser.lightning.utils.FileUtils
 import acr.browser.lightning.utils.MemoryLeakUtils
@@ -23,13 +24,12 @@ import io.reactivex.Scheduler
 import io.reactivex.Single
 import io.reactivex.plugins.RxJavaPlugins
 import javax.inject.Inject
-import javax.inject.Named
 
 class BrowserApp : Application() {
 
     @Inject internal lateinit var developerPreferences: DeveloperPreferences
     @Inject internal lateinit var bookmarkModel: BookmarkRepository
-    @Inject @field:Named("database") internal lateinit var databaseScheduler: Scheduler
+    @Inject @field:DatabaseScheduler internal lateinit var databaseScheduler: Scheduler
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/acr/browser/lightning/adblock/AssetsAdBlocker.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/AssetsAdBlocker.kt
@@ -1,5 +1,6 @@
 package acr.browser.lightning.adblock
 
+import acr.browser.lightning.di.DiskScheduler
 import acr.browser.lightning.extensions.inlineReplace
 import acr.browser.lightning.extensions.inlineTrim
 import acr.browser.lightning.extensions.stringEquals
@@ -13,7 +14,6 @@ import java.net.URI
 import java.net.URISyntaxException
 import java.util.*
 import javax.inject.Inject
-import javax.inject.Named
 import javax.inject.Singleton
 
 /**
@@ -22,8 +22,8 @@ import javax.inject.Singleton
  */
 @Singleton
 class AssetsAdBlocker @Inject internal constructor(
-        private val application: Application,
-        @Named("disk") diskScheduler: Scheduler
+    private val application: Application,
+    @DiskScheduler diskScheduler: Scheduler
 ) : AdBlocker {
 
     private val blockedDomainsSet = HashSet<String>()
@@ -105,9 +105,9 @@ class AssetsAdBlocker @Inject internal constructor(
         @Throws(URISyntaxException::class)
         private fun getDomainName(url: String): String {
             val host = url.indexOf('/', 8)
-                    .takeIf { it != -1 }
-                    ?.let(url::take)
-                    ?: url
+                .takeIf { it != -1 }
+                ?.let(url::take)
+                ?: url
 
             val uri = URI(host)
             val domain = uri.host ?: return host

--- a/app/src/main/java/acr/browser/lightning/adblock/whitelist/SessionWhitelistModel.kt
+++ b/app/src/main/java/acr/browser/lightning/adblock/whitelist/SessionWhitelistModel.kt
@@ -2,12 +2,12 @@ package acr.browser.lightning.adblock.whitelist
 
 import acr.browser.lightning.database.whitelist.AdBlockWhitelistRepository
 import acr.browser.lightning.database.whitelist.WhitelistItem
+import acr.browser.lightning.di.DatabaseScheduler
 import android.util.Log
 import androidx.core.net.toUri
 import io.reactivex.Completable
 import io.reactivex.Scheduler
 import javax.inject.Inject
-import javax.inject.Named
 import javax.inject.Singleton
 
 /**
@@ -16,7 +16,7 @@ import javax.inject.Singleton
 @Singleton
 class SessionWhitelistModel @Inject constructor(
     private val adBlockWhitelistModel: AdBlockWhitelistRepository,
-    @Named("database") private val ioScheduler: Scheduler
+    @DatabaseScheduler private val ioScheduler: Scheduler
 ) : WhitelistModel {
 
     private var whitelistSet = hashSetOf<String>()

--- a/app/src/main/java/acr/browser/lightning/browser/BrowserPresenter.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/BrowserPresenter.kt
@@ -8,6 +8,7 @@ import acr.browser.lightning.constant.INTENT_ORIGIN
 import acr.browser.lightning.constant.SCHEME_BOOKMARKS
 import acr.browser.lightning.constant.SCHEME_HOMEPAGE
 import acr.browser.lightning.controller.UIController
+import acr.browser.lightning.di.MainScheduler
 import acr.browser.lightning.html.bookmark.BookmarkPage
 import acr.browser.lightning.html.homepage.StartPage
 import acr.browser.lightning.preference.UserPreferences
@@ -25,7 +26,6 @@ import io.reactivex.Scheduler
 import io.reactivex.disposables.Disposable
 import io.reactivex.rxkotlin.subscribeBy
 import javax.inject.Inject
-import javax.inject.Named
 
 /**
  * Presenter in charge of keeping track of the current tab and setting the current tab of the
@@ -35,7 +35,7 @@ class BrowserPresenter(private val view: BrowserView, private val isIncognito: B
 
     @Inject internal lateinit var application: Application
     @Inject internal lateinit var userPreferences: UserPreferences
-    @Inject @field:Named("main") internal lateinit var mainScheduler: Scheduler
+    @Inject @field:MainScheduler internal lateinit var mainScheduler: Scheduler
     private val tabsModel: TabsManager
     private var currentTab: LightningView? = null
     private var shouldClose: Boolean = false

--- a/app/src/main/java/acr/browser/lightning/browser/BrowserPresenter.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/BrowserPresenter.kt
@@ -59,7 +59,7 @@ class BrowserPresenter(private val view: BrowserView, private val isIncognito: B
                     // At this point we always have at least a tab in the tab manager
                     view.notifyTabViewInitialized()
                     view.updateTabNumber(tabsModel.size())
-                    onTabChanged(it)
+                    tabChanged(tabsModel.positionOf(it))
                 }
             )
     }

--- a/app/src/main/java/acr/browser/lightning/browser/TabsManager.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/TabsManager.kt
@@ -1,6 +1,9 @@
 package acr.browser.lightning.browser
 
 import acr.browser.lightning.BrowserApp
+import acr.browser.lightning.di.DatabaseScheduler
+import acr.browser.lightning.di.DiskScheduler
+import acr.browser.lightning.di.MainScheduler
 import acr.browser.lightning.html.bookmark.BookmarkPage
 import acr.browser.lightning.html.download.DownloadsPage
 import acr.browser.lightning.html.history.HistoryPage
@@ -27,7 +30,6 @@ import io.reactivex.Scheduler
 import io.reactivex.Single
 import java.util.*
 import javax.inject.Inject
-import javax.inject.Named
 
 /**
  * A manager singleton that holds all the [LightningView] and tracks the current tab. It handles
@@ -51,9 +53,9 @@ class TabsManager {
     @Inject internal lateinit var userPreferences: UserPreferences
     @Inject internal lateinit var app: Application
     @Inject internal lateinit var searchEngineProvider: SearchEngineProvider
-    @Inject @field:Named("database") internal lateinit var databaseScheduler: Scheduler
-    @Inject @field:Named("disk") internal lateinit var diskScheduler: Scheduler
-    @Inject @field:Named("main") internal lateinit var mainScheduler: Scheduler
+    @Inject @field:DatabaseScheduler internal lateinit var databaseScheduler: Scheduler
+    @Inject @field:DiskScheduler internal lateinit var diskScheduler: Scheduler
+    @Inject @field:MainScheduler internal lateinit var mainScheduler: Scheduler
 
     init {
         BrowserApp.appComponent.inject(this)

--- a/app/src/main/java/acr/browser/lightning/browser/TabsManager.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/TabsManager.kt
@@ -1,8 +1,6 @@
 package acr.browser.lightning.browser
 
 import acr.browser.lightning.BrowserApp
-import acr.browser.lightning.R
-import acr.browser.lightning.extensions.resizeAndShow
 import acr.browser.lightning.html.bookmark.BookmarkPage
 import acr.browser.lightning.html.download.DownloadsPage
 import acr.browser.lightning.html.history.HistoryPage
@@ -10,7 +8,9 @@ import acr.browser.lightning.html.homepage.StartPage
 import acr.browser.lightning.preference.UserPreferences
 import acr.browser.lightning.search.SearchEngineProvider
 import acr.browser.lightning.utils.FileUtils
+import acr.browser.lightning.utils.Option
 import acr.browser.lightning.utils.UrlUtils
+import acr.browser.lightning.utils.value
 import acr.browser.lightning.view.*
 import android.app.Activity
 import android.app.Application
@@ -18,13 +18,13 @@ import android.app.SearchManager
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.support.v7.app.AlertDialog
 import android.text.TextUtils
 import android.util.Log
 import android.webkit.URLUtil
-import io.reactivex.*
+import io.reactivex.Maybe
 import io.reactivex.Observable
-import io.reactivex.rxkotlin.subscribeBy
+import io.reactivex.Scheduler
+import io.reactivex.Single
 import java.util.*
 import javax.inject.Inject
 import javax.inject.Named
@@ -81,49 +81,63 @@ class TabsManager {
     }
 
     /**
-     * Restores old tabs that were open before the browser was closed. Handles the intent used to
-     * open the browser.
-     *
-     * @param activity  the activity needed to create tabs.
-     * @param intent    the intent that started the browser activity.
-     * @param incognito whether or not we are in incognito mode.
+     * Initialize the state of the [TabsManager] based on previous state of the browser and with the
+     * new provided [intent] and emit the last tab that should be displayed. By default operates on
+     * a background scheduler and emits on the foreground scheduler.
      */
-    fun initializeTabs(
-        activity: Activity,
-        intent: Intent?,
-        incognito: Boolean
-    ): Completable = Completable.create { emitter ->
-        // Make sure we start with a clean tab list
-        shutdown()
+    fun initializeTabs(activity: Activity, intent: Intent?, incognito: Boolean): Single<LightningView> =
+        Single
+            .just(Option.fromNullable(
+                if (intent?.action == Intent.ACTION_WEB_SEARCH) {
+                    extractSearchFromIntent(intent)
+                } else {
+                    intent?.dataString
+                }
+            ))
+            .doOnSuccess { shutdown() }
+            .subscribeOn(mainScheduler)
+            .flatMapObservable {
+                return@flatMapObservable if (incognito) {
+                    initializeIncognitoMode(it.value(), activity)
+                } else {
+                    initializeRegularMode(it.value(), activity)
+                }
+            }
+            .subscribeOn(databaseScheduler)
+            .observeOn(mainScheduler)
+            .map { newTab(activity, it, incognito) }
+            .lastOrError()
+            .doOnSuccess { finishInitialization() }
 
-        val url: String? = if (intent?.action == Intent.ACTION_WEB_SEARCH) {
-            extractSearchFromIntent(intent)
-        } else {
-            intent?.dataString
+    /**
+     * Returns an [Observable] that emits the [TabInitializer] for incognito mode.
+     */
+    private fun initializeIncognitoMode(initialUrl: String?, activity: Activity): Observable<TabInitializer> =
+        Observable.fromCallable {
+            return@fromCallable initialUrl?.let(::UrlInitializer)
+                ?: HomePageInitializer(userPreferences, activity, databaseScheduler, mainScheduler)
         }
 
-        val tabInitializer = url?.let(::UrlInitializer)
-            ?: HomePageInitializer(userPreferences, activity, databaseScheduler, mainScheduler)
+    /**
+     * Returns an [Observable] that emits the [TabInitializer] for normal operation mode.
+     */
+    private fun initializeRegularMode(initialUrl: String?, activity: Activity): Observable<TabInitializer> =
+        restorePreviousTabs(activity)
+            .concatWith(Maybe.fromCallable<TabInitializer> {
+                return@fromCallable initialUrl?.let {
+                    if (URLUtil.isFileUrl(it)) {
+                        PermissionInitializer(it, activity, HomePageInitializer(userPreferences, activity, databaseScheduler, mainScheduler))
+                    } else {
+                        UrlInitializer(it)
+                    }
+                }
+            })
+            .defaultIfEmpty(HomePageInitializer(userPreferences, activity, databaseScheduler, mainScheduler))
 
-        // If incognito, only create one tab
-        if (incognito) {
-            newTab(activity, tabInitializer, true)
-            finishInitialization()
-            emitter.onComplete()
-            return@create
-        }
-
-        Log.d(TAG, "URL from intent: $url")
-        currentTab = null
-        if (userPreferences.restoreLostTabsEnabled) {
-            restoreLostTabs(url, activity, emitter)
-        } else {
-            newTab(activity, tabInitializer, false)
-            finishInitialization()
-            emitter.onComplete()
-        }
-    }
-
+    /**
+     * Returns the URL for a search [Intent]. If the query is empty, then a null URL will be
+     * returned.
+     */
     fun extractSearchFromIntent(intent: Intent): String? {
         val query = intent.getStringExtra(SearchManager.QUERY)
         val searchUrl = "${searchEngineProvider.provideSearchEngine().queryUrl}${UrlUtils.QUERY_PLACE_HOLDER}"
@@ -135,71 +149,24 @@ class TabsManager {
         }
     }
 
-    private fun restoreLostTabs(
-        newTabUrl: String?,
-        activity: Activity,
-        emitter: CompletableEmitter
-    ) = restoreState()
-        .subscribeOn(diskScheduler)
-        .observeOn(mainScheduler)
-        .subscribeBy(
-            onNext = { bundle ->
-                val url = bundle.getString(URL_KEY)
-                if (url != null) {
-                    val initializer = AsyncUrlInitializer(when {
-                        UrlUtils.isBookmarkUrl(url) -> BookmarkPage(activity).createBookmarkPage()
-                        UrlUtils.isDownloadsUrl(url) -> DownloadsPage().getDownloadsPage()
-                        UrlUtils.isStartPageUrl(url) -> StartPage().createHomePage()
-                        UrlUtils.isHistoryUrl(url) -> HistoryPage().createHistoryPage()
-                        else -> StartPage().createHomePage()
-                    }, databaseScheduler, mainScheduler)
-
-                    newTab(activity, initializer, false)
-                } else {
-                    newTab(activity, BundleInitializer(bundle), false)
-                }
-            },
-            onComplete = {
-                if (newTabUrl != null) {
-                    if (URLUtil.isFileUrl(newTabUrl)) {
-                        AlertDialog.Builder(activity).apply {
-                            setTitle(R.string.title_warning)
-                            setMessage(R.string.message_blocked_local)
-                            setOnDismissListener {
-                                if (tabList.isEmpty()) {
-                                    newTab(
-                                        activity,
-                                        HomePageInitializer(userPreferences, activity, databaseScheduler, mainScheduler),
-                                        false
-                                    )
-                                }
-                                finishInitialization()
-                                emitter.onComplete()
-                            }
-                            setNegativeButton(android.R.string.cancel, null)
-                            setPositiveButton(R.string.action_open) { _, _ ->
-                                newTab(activity, UrlInitializer(newTabUrl), false)
-                            }
-                        }.resizeAndShow()
-                    } else {
-                        newTab(activity, UrlInitializer(newTabUrl), false)
-                        finishInitialization()
-                        emitter.onComplete()
-                    }
-                } else if (tabList.isEmpty()) {
-                    newTab(
-                        activity,
-                        HomePageInitializer(userPreferences, activity, databaseScheduler, mainScheduler),
-                        false
-                    )
-                    finishInitialization()
-                    emitter.onComplete()
-                } else {
-                    finishInitialization()
-                    emitter.onComplete()
-                }
-            }
-        )
+    /**
+     * Returns an observable that emits the [TabInitializer] for each previously opened tab as
+     * saved on disk. Can potentially be empty.
+     */
+    private fun restorePreviousTabs(
+        activity: Activity
+    ): Observable<TabInitializer> = readSavedStateFromDisk()
+        .map { bundle ->
+            return@map bundle.getString(URL_KEY)?.let { url ->
+                AsyncUrlInitializer(when {
+                    UrlUtils.isBookmarkUrl(url) -> BookmarkPage(activity).createBookmarkPage()
+                    UrlUtils.isDownloadsUrl(url) -> DownloadsPage().getDownloadsPage()
+                    UrlUtils.isStartPageUrl(url) -> StartPage().createHomePage()
+                    UrlUtils.isHistoryUrl(url) -> HistoryPage().createHistoryPage()
+                    else -> StartPage().createHomePage()
+                }, databaseScheduler, mainScheduler)
+            } ?: BundleInitializer(bundle)
+        }
 
 
     /**
@@ -249,7 +216,7 @@ class TabsManager {
      * tab is also released for garbage collection.
      */
     fun shutdown() {
-        tabList.indices.forEach { deleteTab(0) }
+        repeat(tabList.size) { deleteTab(0) }
         isInitialized = false
         currentTab = null
     }
@@ -389,11 +356,11 @@ class TabsManager {
     fun clearSavedState() = FileUtils.deleteBundleInStorage(app, BUNDLE_STORAGE)
 
     /**
-     * Restores the previously saved tabs from the bundle stored in persistent file storage. It will
-     * create new tabs for each tab saved and will delete the saved instance file when restoration
-     * is complete.
+     * Creates an [Observable] that emits the [Bundle] state stored for each previously opened tab
+     * on disk. After the list of bundle [Bundle] is read off disk, the old state will be deleted.
+     * Can potentially be empty.
      */
-    private fun restoreState(): Observable<Bundle> = Maybe
+    private fun readSavedStateFromDisk(): Observable<Bundle> = Maybe
         .fromCallable { FileUtils.readBundleFromStorage(app, BUNDLE_STORAGE) }
         .flattenAsObservable { bundle ->
             bundle.keySet()

--- a/app/src/main/java/acr/browser/lightning/browser/TabsManager.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/TabsManager.kt
@@ -35,7 +35,7 @@ import javax.inject.Named
  */
 class TabsManager {
 
-    private val tabList = ArrayList<LightningView>(1)
+    private val tabList = arrayListOf<LightningView>()
     /**
      * Return the current [LightningView] or null if no current tab has been set.
      *
@@ -404,9 +404,9 @@ class TabsManager {
             Log.e(TAG, "Returning a null LightningView requested for position: $position")
             null
         } else {
-            val tab = tabList[position]
-            currentTab = tab
-            tab
+            tabList[position].also {
+                currentTab = it
+            }
         }
     }
 

--- a/app/src/main/java/acr/browser/lightning/browser/activity/BrowserActivity.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/activity/BrowserActivity.kt
@@ -823,7 +823,7 @@ abstract class BrowserActivity : ThemableBrowserActivity(), BrowserView, UIContr
     private fun addBookmark(title: String, url: String) {
         bookmarkManager.addBookmarkIfNotExists(Bookmark.Entry(url, title, 0, null))
             .subscribeOn(databaseScheduler)
-            .observeOn(AndroidSchedulers.mainThread())
+            .observeOn(mainScheduler)
             .subscribe { boolean ->
                 if (boolean) {
                     suggestionsAdapter?.refreshBookmarks()
@@ -836,7 +836,7 @@ abstract class BrowserActivity : ThemableBrowserActivity(), BrowserView, UIContr
     private fun deleteBookmark(title: String, url: String) {
         bookmarkManager.deleteBookmark(Bookmark.Entry(url, title, 0, null))
             .subscribeOn(databaseScheduler)
-            .observeOn(AndroidSchedulers.mainThread())
+            .observeOn(mainScheduler)
             .subscribe { boolean ->
                 if (boolean) {
                     suggestionsAdapter?.refreshBookmarks()
@@ -1061,7 +1061,7 @@ abstract class BrowserActivity : ThemableBrowserActivity(), BrowserView, UIContr
         if (!UrlUtils.isSpecialUrl(url)) {
             bookmarkManager.isBookmark(url)
                 .subscribeOn(databaseScheduler)
-                .observeOn(AndroidSchedulers.mainThread())
+                .observeOn(mainScheduler)
                 .subscribe { boolean ->
                     if (boolean) {
                         deleteBookmark(title, url)
@@ -1256,7 +1256,7 @@ abstract class BrowserActivity : ThemableBrowserActivity(), BrowserView, UIContr
 
         networkDisposable = networkConnectivityModel
             .connectivity()
-            .subscribeOn(AndroidSchedulers.mainThread())
+            .subscribeOn(mainScheduler)
             .subscribe { connected ->
                 Log.d(TAG, "Network connected: $connected")
                 tabsManager.notifyConnectionStatus(connected)

--- a/app/src/main/java/acr/browser/lightning/browser/activity/BrowserActivity.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/activity/BrowserActivity.kt
@@ -16,6 +16,8 @@ import acr.browser.lightning.database.Bookmark
 import acr.browser.lightning.database.HistoryEntry
 import acr.browser.lightning.database.bookmark.BookmarkRepository
 import acr.browser.lightning.database.history.HistoryRepository
+import acr.browser.lightning.di.DatabaseScheduler
+import acr.browser.lightning.di.MainScheduler
 import acr.browser.lightning.dialog.BrowserDialog
 import acr.browser.lightning.dialog.DialogItem
 import acr.browser.lightning.dialog.LightningDialogBuilder
@@ -148,8 +150,8 @@ abstract class BrowserActivity : ThemableBrowserActivity(), BrowserView, UIContr
     @Inject internal lateinit var inputMethodManager: InputMethodManager
     @Inject internal lateinit var clipboardManager: ClipboardManager
     @Inject internal lateinit var notificationManager: NotificationManager
-    @Inject @field:Named("database") internal lateinit var databaseScheduler: Scheduler
-    @Inject @field:Named("main") internal lateinit var mainScheduler: Scheduler
+    @Inject @field:DatabaseScheduler internal lateinit var databaseScheduler: Scheduler
+    @Inject @field:MainScheduler internal lateinit var mainScheduler: Scheduler
 
     private val tabsManager: TabsManager = TabsManager()
 

--- a/app/src/main/java/acr/browser/lightning/browser/fragment/BookmarksFragment.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/fragment/BookmarksFragment.kt
@@ -10,6 +10,9 @@ import acr.browser.lightning.constant.LOAD_READING_URL
 import acr.browser.lightning.controller.UIController
 import acr.browser.lightning.database.Bookmark
 import acr.browser.lightning.database.bookmark.BookmarkRepository
+import acr.browser.lightning.di.DatabaseScheduler
+import acr.browser.lightning.di.MainScheduler
+import acr.browser.lightning.di.NetworkScheduler
 import acr.browser.lightning.dialog.LightningDialogBuilder
 import acr.browser.lightning.favicon.FaviconModel
 import acr.browser.lightning.preference.UserPreferences
@@ -38,7 +41,6 @@ import io.reactivex.rxkotlin.subscribeBy
 import kotlinx.android.synthetic.main.bookmark_drawer.*
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
-import javax.inject.Named
 
 class BookmarksFragment : Fragment(), View.OnClickListener, View.OnLongClickListener, BookmarksView {
 
@@ -52,9 +54,9 @@ class BookmarksFragment : Fragment(), View.OnClickListener, View.OnLongClickList
 
     @Inject internal lateinit var faviconModel: FaviconModel
 
-    @Inject @field:Named("database") internal lateinit var databaseScheduler: Scheduler
-    @Inject @field:Named("network") internal lateinit var networkScheduler: Scheduler
-    @Inject @field:Named("main") internal lateinit var mainScheduler: Scheduler
+    @Inject @field:DatabaseScheduler internal lateinit var databaseScheduler: Scheduler
+    @Inject @field:NetworkScheduler internal lateinit var networkScheduler: Scheduler
+    @Inject @field:MainScheduler internal lateinit var mainScheduler: Scheduler
 
     private lateinit var uiController: UIController
 

--- a/app/src/main/java/acr/browser/lightning/di/AppModule.kt
+++ b/app/src/main/java/acr/browser/lightning/di/AppModule.kt
@@ -28,6 +28,7 @@ import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import javax.inject.Named
+import javax.inject.Qualifier
 import javax.inject.Singleton
 
 @Module
@@ -70,22 +71,22 @@ class AppModule(private val browserApp: BrowserApp) {
     fun providesShortcutManager() = browserApp.getSystemService(Context.SHORTCUT_SERVICE) as ShortcutManager
 
     @Provides
-    @Named("database")
+    @DatabaseScheduler
     @Singleton
     fun providesIoThread(): Scheduler = Schedulers.from(Executors.newSingleThreadExecutor())
 
     @Provides
-    @Named("disk")
+    @DiskScheduler
     @Singleton
     fun providesDiskThread(): Scheduler = Schedulers.from(Executors.newSingleThreadExecutor())
 
     @Provides
-    @Named("network")
+    @NetworkScheduler
     @Singleton
     fun providesNetworkThread(): Scheduler = Schedulers.from(ThreadPoolExecutor(0, 4, 60, TimeUnit.SECONDS, LinkedBlockingDeque()))
 
     @Provides
-    @Named("main")
+    @MainScheduler
     @Singleton
     fun providesMainThread(): Scheduler = AndroidSchedulers.mainThread()
 
@@ -135,8 +136,20 @@ class AppModule(private val browserApp: BrowserApp) {
 object Name {
     const val DEVELOPER_SETTINGS = "developer_settings"
     const val SETTINGS = "settings"
-
-    const val DATABASE = "database"
-    const val DISK = "disk"
-    const val NETWORK = "network"
 }
+
+@Qualifier
+@Retention(AnnotationRetention.SOURCE)
+annotation class MainScheduler
+
+@Qualifier
+@Retention(AnnotationRetention.SOURCE)
+annotation class DiskScheduler
+
+@Qualifier
+@Retention(AnnotationRetention.SOURCE)
+annotation class NetworkScheduler
+
+@Qualifier
+@Retention(AnnotationRetention.SOURCE)
+annotation class DatabaseScheduler

--- a/app/src/main/java/acr/browser/lightning/dialog/LightningDialogBuilder.kt
+++ b/app/src/main/java/acr/browser/lightning/dialog/LightningDialogBuilder.kt
@@ -10,6 +10,7 @@ import acr.browser.lightning.database.asFolder
 import acr.browser.lightning.database.bookmark.BookmarkRepository
 import acr.browser.lightning.database.downloads.DownloadsRepository
 import acr.browser.lightning.database.history.HistoryRepository
+import acr.browser.lightning.di.DatabaseScheduler
 import acr.browser.lightning.download.DownloadHandler
 import acr.browser.lightning.html.bookmark.BookmarkPage
 import acr.browser.lightning.preference.UserPreferences
@@ -26,7 +27,6 @@ import androidx.core.net.toUri
 import io.reactivex.Scheduler
 import io.reactivex.android.schedulers.AndroidSchedulers
 import javax.inject.Inject
-import javax.inject.Named
 
 /**
  * A builder of various dialogs.
@@ -37,7 +37,7 @@ class LightningDialogBuilder @Inject constructor(
     private val historyModel: HistoryRepository,
     private val userPreferences: UserPreferences,
     private val downloadHandler: DownloadHandler,
-    @Named("database") private val databaseScheduler: Scheduler
+    @DatabaseScheduler private val databaseScheduler: Scheduler
 ) {
 
     enum class NewTab {

--- a/app/src/main/java/acr/browser/lightning/dialog/LightningDialogBuilder.kt
+++ b/app/src/main/java/acr/browser/lightning/dialog/LightningDialogBuilder.kt
@@ -11,6 +11,7 @@ import acr.browser.lightning.database.bookmark.BookmarkRepository
 import acr.browser.lightning.database.downloads.DownloadsRepository
 import acr.browser.lightning.database.history.HistoryRepository
 import acr.browser.lightning.di.DatabaseScheduler
+import acr.browser.lightning.di.MainScheduler
 import acr.browser.lightning.download.DownloadHandler
 import acr.browser.lightning.html.bookmark.BookmarkPage
 import acr.browser.lightning.preference.UserPreferences
@@ -25,7 +26,6 @@ import android.widget.AutoCompleteTextView
 import android.widget.EditText
 import androidx.core.net.toUri
 import io.reactivex.Scheduler
-import io.reactivex.android.schedulers.AndroidSchedulers
 import javax.inject.Inject
 
 /**
@@ -37,7 +37,8 @@ class LightningDialogBuilder @Inject constructor(
     private val historyModel: HistoryRepository,
     private val userPreferences: UserPreferences,
     private val downloadHandler: DownloadHandler,
-    @DatabaseScheduler private val databaseScheduler: Scheduler
+    @DatabaseScheduler private val databaseScheduler: Scheduler,
+    @MainScheduler private val mainScheduler: Scheduler
 ) {
 
     enum class NewTab {
@@ -67,7 +68,7 @@ class LightningDialogBuilder @Inject constructor(
         } else {
             bookmarkManager.findBookmarkForUrl(url)
                 .subscribeOn(databaseScheduler)
-                .observeOn(AndroidSchedulers.mainThread())
+                .observeOn(mainScheduler)
                 .subscribe { historyItem ->
                     // TODO: 6/14/17 figure out solution to case where slashes get appended to root urls causing the item to not exist
                     showLongPressedDialogForBookmarkUrl(activity, uiController, historyItem)
@@ -98,7 +99,7 @@ class LightningDialogBuilder @Inject constructor(
         DialogItem(R.string.dialog_remove_bookmark) {
             bookmarkManager.deleteBookmark(entry)
                 .subscribeOn(databaseScheduler)
-                .observeOn(AndroidSchedulers.mainThread())
+                .observeOn(mainScheduler)
                 .subscribe { success ->
                     if (success) {
                         uiController.handleBookmarkDeleted(entry)
@@ -124,7 +125,7 @@ class LightningDialogBuilder @Inject constructor(
         DialogItem(R.string.dialog_delete_all_downloads) {
             downloadsModel.deleteAllDownloads()
                 .subscribeOn(databaseScheduler)
-                .observeOn(AndroidSchedulers.mainThread())
+                .observeOn(mainScheduler)
                 .subscribe(uiController::handleDownloadDeleted)
         })
 
@@ -146,7 +147,7 @@ class LightningDialogBuilder @Inject constructor(
 
         bookmarkManager.getFolderNames()
             .subscribeOn(databaseScheduler)
-            .observeOn(AndroidSchedulers.mainThread())
+            .observeOn(mainScheduler)
             .subscribe { folders ->
                 val suggestionsAdapter = ArrayAdapter(activity,
                     android.R.layout.simple_dropdown_item_1line, folders)
@@ -162,7 +163,7 @@ class LightningDialogBuilder @Inject constructor(
                     )
                     bookmarkManager.editBookmark(entry, editedItem)
                         .subscribeOn(databaseScheduler)
-                        .observeOn(AndroidSchedulers.mainThread())
+                        .observeOn(mainScheduler)
                         .subscribe(uiController::handleBookmarksChange)
                 }
                 val dialog = editBookmarkDialog.show()
@@ -181,7 +182,7 @@ class LightningDialogBuilder @Inject constructor(
         DialogItem(R.string.dialog_remove_folder) {
             bookmarkManager.deleteFolder(folder.title)
                 .subscribeOn(databaseScheduler)
-                .observeOn(AndroidSchedulers.mainThread())
+                .observeOn(mainScheduler)
                 .subscribe {
                     uiController.handleBookmarkDeleted(folder)
                 }
@@ -200,7 +201,7 @@ class LightningDialogBuilder @Inject constructor(
             val oldTitle = folder.title
             bookmarkManager.renameFolder(oldTitle, text)
                 .subscribeOn(databaseScheduler)
-                .observeOn(AndroidSchedulers.mainThread())
+                .observeOn(mainScheduler)
                 .subscribe(uiController::handleBookmarksChange)
         }
     }
@@ -228,7 +229,7 @@ class LightningDialogBuilder @Inject constructor(
         DialogItem(R.string.dialog_remove_from_history) {
             historyModel.deleteHistoryEntry(url)
                 .subscribeOn(databaseScheduler)
-                .observeOn(AndroidSchedulers.mainThread())
+                .observeOn(mainScheduler)
                 .subscribe(uiController::handleHistoryChange)
         })
 

--- a/app/src/main/java/acr/browser/lightning/download/DownloadHandler.java
+++ b/app/src/main/java/acr/browser/lightning/download/DownloadHandler.java
@@ -25,7 +25,6 @@ import java.io.File;
 import java.io.IOException;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Singleton;
 
 import acr.browser.lightning.BrowserApp;
@@ -36,6 +35,8 @@ import acr.browser.lightning.constant.Constants;
 import acr.browser.lightning.controller.UIController;
 import acr.browser.lightning.database.downloads.DownloadEntry;
 import acr.browser.lightning.database.downloads.DownloadsRepository;
+import acr.browser.lightning.di.DatabaseScheduler;
+import acr.browser.lightning.di.NetworkScheduler;
 import acr.browser.lightning.dialog.BrowserDialog;
 import acr.browser.lightning.extensions.ActivityExtensions;
 import acr.browser.lightning.preference.UserPreferences;
@@ -59,8 +60,8 @@ public class DownloadHandler {
 
     @Inject DownloadsRepository downloadsRepository;
     @Inject DownloadManager downloadManager;
-    @Inject @Named("database") Scheduler databaseScheduler;
-    @Inject @Named("network") Scheduler networkScheduler;
+    @Inject @DatabaseScheduler Scheduler databaseScheduler;
+    @Inject @NetworkScheduler Scheduler networkScheduler;
 
     @Inject
     public DownloadHandler() {

--- a/app/src/main/java/acr/browser/lightning/download/DownloadHandler.java
+++ b/app/src/main/java/acr/browser/lightning/download/DownloadHandler.java
@@ -36,6 +36,7 @@ import acr.browser.lightning.controller.UIController;
 import acr.browser.lightning.database.downloads.DownloadEntry;
 import acr.browser.lightning.database.downloads.DownloadsRepository;
 import acr.browser.lightning.di.DatabaseScheduler;
+import acr.browser.lightning.di.MainScheduler;
 import acr.browser.lightning.di.NetworkScheduler;
 import acr.browser.lightning.dialog.BrowserDialog;
 import acr.browser.lightning.extensions.ActivityExtensions;
@@ -44,7 +45,6 @@ import acr.browser.lightning.utils.FileUtils;
 import acr.browser.lightning.utils.Utils;
 import acr.browser.lightning.view.LightningView;
 import io.reactivex.Scheduler;
-import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Consumer;
 
@@ -62,6 +62,7 @@ public class DownloadHandler {
     @Inject DownloadManager downloadManager;
     @Inject @DatabaseScheduler Scheduler databaseScheduler;
     @Inject @NetworkScheduler Scheduler networkScheduler;
+    @Inject @MainScheduler Scheduler mainScheduler;
 
     @Inject
     public DownloadHandler() {
@@ -252,7 +253,7 @@ public class DownloadHandler {
             final Disposable disposable = new FetchUrlMimeType(downloadManager, request, addressString, cookies, userAgent)
                 .create()
                 .subscribeOn(networkScheduler)
-                .observeOn(AndroidSchedulers.mainThread())
+                .observeOn(mainScheduler)
                 .subscribe(new Consumer<FetchUrlMimeType.Result>() {
                     @Override
                     public void accept(FetchUrlMimeType.Result result) {

--- a/app/src/main/java/acr/browser/lightning/extensions/ObservableExtensions.kt
+++ b/app/src/main/java/acr/browser/lightning/extensions/ObservableExtensions.kt
@@ -1,0 +1,10 @@
+package acr.browser.lightning.extensions
+
+import io.reactivex.Observable
+
+/**
+ * Filters the [Observable] to only instances of [T].
+ */
+inline fun <reified T> Observable<out Any>.filterInstance(): Observable<T> {
+    return this.filter { it is T }.map { it as T }
+}

--- a/app/src/main/java/acr/browser/lightning/html/bookmark/BookmarkPage.kt
+++ b/app/src/main/java/acr/browser/lightning/html/bookmark/BookmarkPage.kt
@@ -8,6 +8,8 @@ import acr.browser.lightning.R
 import acr.browser.lightning.constant.FILE
 import acr.browser.lightning.database.Bookmark
 import acr.browser.lightning.database.bookmark.BookmarkRepository
+import acr.browser.lightning.di.DatabaseScheduler
+import acr.browser.lightning.di.DiskScheduler
 import acr.browser.lightning.extensions.safeUse
 import acr.browser.lightning.favicon.FaviconModel
 import acr.browser.lightning.utils.ThemeUtils
@@ -21,15 +23,14 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.FileWriter
 import javax.inject.Inject
-import javax.inject.Named
 
 class BookmarkPage(activity: Activity) {
 
     @Inject internal lateinit var app: Application
     @Inject internal lateinit var bookmarkModel: BookmarkRepository
     @Inject internal lateinit var faviconModel: FaviconModel
-    @Inject @field:Named("database") internal lateinit var databaseScheduler: Scheduler
-    @Inject @field:Named("disk") internal lateinit var diskScheduler: Scheduler
+    @Inject @field:DatabaseScheduler internal lateinit var databaseScheduler: Scheduler
+    @Inject @field:DiskScheduler internal lateinit var diskScheduler: Scheduler
 
     private val folderIcon = ThemeUtils.getThemedBitmap(activity, R.drawable.ic_folder, false)
 

--- a/app/src/main/java/acr/browser/lightning/reading/activity/ReadingActivity.java
+++ b/app/src/main/java/acr/browser/lightning/reading/activity/ReadingActivity.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 import acr.browser.lightning.BrowserApp;
 import acr.browser.lightning.R;
 import acr.browser.lightning.constant.Constants;
+import acr.browser.lightning.di.MainScheduler;
 import acr.browser.lightning.di.NetworkScheduler;
 import acr.browser.lightning.dialog.BrowserDialog;
 import acr.browser.lightning.preference.UserPreferences;
@@ -41,7 +42,6 @@ import io.reactivex.Scheduler;
 import io.reactivex.Single;
 import io.reactivex.SingleEmitter;
 import io.reactivex.SingleOnSubscribe;
-import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.functions.Consumer;
 
@@ -54,6 +54,7 @@ public class ReadingActivity extends AppCompatActivity {
 
     @Inject UserPreferences mUserPreferences;
     @Inject @NetworkScheduler Scheduler mNetworkScheduler;
+    @Inject @MainScheduler Scheduler mMainScheduler;
 
     private boolean mInvert;
     @Nullable private String mUrl = null;
@@ -168,7 +169,7 @@ public class ReadingActivity extends AppCompatActivity {
 
         mPageLoaderSubscription = loadPage(mUrl)
             .subscribeOn(mNetworkScheduler)
-            .observeOn(AndroidSchedulers.mainThread())
+            .observeOn(mMainScheduler)
             .subscribe(new Consumer<ReaderInfo>() {
                 @Override
                 public void accept(@NonNull ReaderInfo readerInfo) {

--- a/app/src/main/java/acr/browser/lightning/reading/activity/ReadingActivity.java
+++ b/app/src/main/java/acr/browser/lightning/reading/activity/ReadingActivity.java
@@ -24,11 +24,11 @@ import android.widget.SeekBar.OnSeekBarChangeListener;
 import android.widget.TextView;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import acr.browser.lightning.BrowserApp;
 import acr.browser.lightning.R;
 import acr.browser.lightning.constant.Constants;
+import acr.browser.lightning.di.NetworkScheduler;
 import acr.browser.lightning.dialog.BrowserDialog;
 import acr.browser.lightning.preference.UserPreferences;
 import acr.browser.lightning.reading.HtmlFetcher;
@@ -53,7 +53,7 @@ public class ReadingActivity extends AppCompatActivity {
     @BindView(R.id.textViewBody) TextView mBody;
 
     @Inject UserPreferences mUserPreferences;
-    @Inject @Named("network") Scheduler mNetworkScheduler;
+    @Inject @NetworkScheduler Scheduler mNetworkScheduler;
 
     private boolean mInvert;
     @Nullable private String mUrl = null;

--- a/app/src/main/java/acr/browser/lightning/search/SuggestionsAdapter.kt
+++ b/app/src/main/java/acr/browser/lightning/search/SuggestionsAdapter.kt
@@ -8,6 +8,8 @@ import acr.browser.lightning.database.SearchSuggestion
 import acr.browser.lightning.database.WebPage
 import acr.browser.lightning.database.bookmark.BookmarkRepository
 import acr.browser.lightning.database.history.HistoryRepository
+import acr.browser.lightning.di.DatabaseScheduler
+import acr.browser.lightning.di.NetworkScheduler
 import acr.browser.lightning.preference.UserPreferences
 import acr.browser.lightning.search.suggestions.NoOpSuggestionsRepository
 import acr.browser.lightning.search.suggestions.SuggestionsRepository
@@ -29,7 +31,6 @@ import io.reactivex.schedulers.Schedulers
 import java.util.*
 import java.util.concurrent.Executors
 import javax.inject.Inject
-import javax.inject.Named
 
 class SuggestionsAdapter(
     private val context: Context,
@@ -56,8 +57,8 @@ class SuggestionsAdapter(
     @Inject internal lateinit var userPreferences: UserPreferences
     @Inject internal lateinit var historyModel: HistoryRepository
     @Inject internal lateinit var application: Application
-    @Inject @field:Named("database") internal lateinit var databaseScheduler: Scheduler
-    @Inject @field:Named("network") internal lateinit var networkScheduler: Scheduler
+    @Inject @field:DatabaseScheduler internal lateinit var databaseScheduler: Scheduler
+    @Inject @field:NetworkScheduler internal lateinit var networkScheduler: Scheduler
     @Inject internal lateinit var searchEngineProvider: SearchEngineProvider
 
     private val allBookmarks = arrayListOf<Bookmark.Entry>()

--- a/app/src/main/java/acr/browser/lightning/settings/fragment/BookmarkSettingsFragment.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/fragment/BookmarkSettingsFragment.kt
@@ -8,6 +8,7 @@ import acr.browser.lightning.R
 import acr.browser.lightning.database.bookmark.BookmarkExporter
 import acr.browser.lightning.database.bookmark.BookmarkRepository
 import acr.browser.lightning.di.DatabaseScheduler
+import acr.browser.lightning.di.MainScheduler
 import acr.browser.lightning.dialog.BrowserDialog
 import acr.browser.lightning.dialog.DialogItem
 import acr.browser.lightning.extensions.snackbar
@@ -22,7 +23,6 @@ import androidx.core.widget.toast
 import com.anthonycr.grant.PermissionsManager
 import com.anthonycr.grant.PermissionsResultAction
 import io.reactivex.Scheduler
-import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
 import io.reactivex.rxkotlin.subscribeBy
 import java.io.File
@@ -34,6 +34,7 @@ class BookmarkSettingsFragment : AbstractSettingsFragment() {
     @Inject internal lateinit var bookmarkRepository: BookmarkRepository
     @Inject internal lateinit var application: Application
     @Inject @field:DatabaseScheduler internal lateinit var databaseScheduler: Scheduler
+    @Inject @field:MainScheduler internal lateinit var mainScheduler: Scheduler
 
     private var importSubscription: Disposable? = null
     private var exportSubscription: Disposable? = null
@@ -82,7 +83,7 @@ class BookmarkSettingsFragment : AbstractSettingsFragment() {
                             exportSubscription?.dispose()
                             exportSubscription = BookmarkExporter.exportBookmarksToFile(list, exportFile)
                                 .subscribeOn(databaseScheduler)
-                                .observeOn(AndroidSchedulers.mainThread())
+                                .observeOn(mainScheduler)
                                 .subscribeBy(
                                     onComplete = {
                                         activity?.apply {
@@ -197,12 +198,12 @@ class BookmarkSettingsFragment : AbstractSettingsFragment() {
                 importSubscription = BookmarkExporter
                     .importBookmarksFromFile(fileList[which])
                     .subscribeOn(databaseScheduler)
-                    .observeOn(AndroidSchedulers.mainThread())
+                    .observeOn(mainScheduler)
                     .subscribeBy(
                         onSuccess = { importList ->
                             bookmarkRepository.addBookmarkList(importList)
                                 .subscribeOn(databaseScheduler)
-                                .observeOn(AndroidSchedulers.mainThread())
+                                .observeOn(mainScheduler)
                                 .subscribe {
                                     activity?.apply {
                                         snackbar("${importList.size} ${getString(R.string.message_import)}")

--- a/app/src/main/java/acr/browser/lightning/settings/fragment/BookmarkSettingsFragment.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/fragment/BookmarkSettingsFragment.kt
@@ -7,6 +7,7 @@ import acr.browser.lightning.BrowserApp
 import acr.browser.lightning.R
 import acr.browser.lightning.database.bookmark.BookmarkExporter
 import acr.browser.lightning.database.bookmark.BookmarkRepository
+import acr.browser.lightning.di.DatabaseScheduler
 import acr.browser.lightning.dialog.BrowserDialog
 import acr.browser.lightning.dialog.DialogItem
 import acr.browser.lightning.extensions.snackbar
@@ -27,13 +28,12 @@ import io.reactivex.rxkotlin.subscribeBy
 import java.io.File
 import java.util.*
 import javax.inject.Inject
-import javax.inject.Named
 
 class BookmarkSettingsFragment : AbstractSettingsFragment() {
 
     @Inject internal lateinit var bookmarkRepository: BookmarkRepository
     @Inject internal lateinit var application: Application
-    @Inject @field:Named("database") internal lateinit var databaseScheduler: Scheduler
+    @Inject @field:DatabaseScheduler internal lateinit var databaseScheduler: Scheduler
 
     private var importSubscription: Disposable? = null
     private var exportSubscription: Disposable? = null

--- a/app/src/main/java/acr/browser/lightning/settings/fragment/PrivacySettingsFragment.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/fragment/PrivacySettingsFragment.kt
@@ -3,6 +3,7 @@ package acr.browser.lightning.settings.fragment
 import acr.browser.lightning.BrowserApp
 import acr.browser.lightning.R
 import acr.browser.lightning.database.history.HistoryRepository
+import acr.browser.lightning.di.DatabaseScheduler
 import acr.browser.lightning.dialog.BrowserDialog
 import acr.browser.lightning.dialog.DialogItem
 import acr.browser.lightning.extensions.snackbar
@@ -16,13 +17,12 @@ import io.reactivex.Completable
 import io.reactivex.Scheduler
 import io.reactivex.android.schedulers.AndroidSchedulers
 import javax.inject.Inject
-import javax.inject.Named
 
 class PrivacySettingsFragment : AbstractSettingsFragment() {
 
     @Inject internal lateinit var historyRepository: HistoryRepository
     @Inject internal lateinit var userPreferences: UserPreferences
-    @Inject @field:Named("database") internal lateinit var databaseScheduler: Scheduler
+    @Inject @field:DatabaseScheduler internal lateinit var databaseScheduler: Scheduler
 
     override fun providePreferencesXmlResource() = R.xml.preference_privacy
 

--- a/app/src/main/java/acr/browser/lightning/settings/fragment/PrivacySettingsFragment.kt
+++ b/app/src/main/java/acr/browser/lightning/settings/fragment/PrivacySettingsFragment.kt
@@ -4,6 +4,7 @@ import acr.browser.lightning.BrowserApp
 import acr.browser.lightning.R
 import acr.browser.lightning.database.history.HistoryRepository
 import acr.browser.lightning.di.DatabaseScheduler
+import acr.browser.lightning.di.MainScheduler
 import acr.browser.lightning.dialog.BrowserDialog
 import acr.browser.lightning.dialog.DialogItem
 import acr.browser.lightning.extensions.snackbar
@@ -15,7 +16,6 @@ import android.os.Bundle
 import android.webkit.WebView
 import io.reactivex.Completable
 import io.reactivex.Scheduler
-import io.reactivex.android.schedulers.AndroidSchedulers
 import javax.inject.Inject
 
 class PrivacySettingsFragment : AbstractSettingsFragment() {
@@ -23,6 +23,7 @@ class PrivacySettingsFragment : AbstractSettingsFragment() {
     @Inject internal lateinit var historyRepository: HistoryRepository
     @Inject internal lateinit var userPreferences: UserPreferences
     @Inject @field:DatabaseScheduler internal lateinit var databaseScheduler: Scheduler
+    @Inject @field:MainScheduler internal lateinit var mainScheduler: Scheduler
 
     override fun providePreferencesXmlResource() = R.xml.preference_privacy
 
@@ -36,105 +37,105 @@ class PrivacySettingsFragment : AbstractSettingsFragment() {
         clickablePreference(preference = SETTINGS_CLEARWEBSTORAGE, onClick = this::clearWebStorage)
 
         checkBoxPreference(
-                preference = SETTINGS_LOCATION,
-                isChecked = userPreferences.locationEnabled,
-                onCheckChange = { userPreferences.locationEnabled = it }
+            preference = SETTINGS_LOCATION,
+            isChecked = userPreferences.locationEnabled,
+            onCheckChange = { userPreferences.locationEnabled = it }
         )
 
         checkBoxPreference(
-                preference = SETTINGS_THIRDPCOOKIES,
-                isChecked = userPreferences.blockThirdPartyCookiesEnabled,
-                isEnabled = ApiUtils.doesSupportThirdPartyCookieBlocking(),
-                onCheckChange = { userPreferences.blockThirdPartyCookiesEnabled = it }
+            preference = SETTINGS_THIRDPCOOKIES,
+            isChecked = userPreferences.blockThirdPartyCookiesEnabled,
+            isEnabled = ApiUtils.doesSupportThirdPartyCookieBlocking(),
+            onCheckChange = { userPreferences.blockThirdPartyCookiesEnabled = it }
         )
 
         checkBoxPreference(
-                preference = SETTINGS_SAVEPASSWORD,
-                isChecked = userPreferences.savePasswordsEnabled,
-                onCheckChange = { userPreferences.savePasswordsEnabled = it }
+            preference = SETTINGS_SAVEPASSWORD,
+            isChecked = userPreferences.savePasswordsEnabled,
+            onCheckChange = { userPreferences.savePasswordsEnabled = it }
         )
 
         checkBoxPreference(
-                preference = SETTINGS_CACHEEXIT,
-                isChecked = userPreferences.clearCacheExit,
-                onCheckChange = { userPreferences.clearCacheExit = it }
+            preference = SETTINGS_CACHEEXIT,
+            isChecked = userPreferences.clearCacheExit,
+            onCheckChange = { userPreferences.clearCacheExit = it }
         )
 
         checkBoxPreference(
-                preference = SETTINGS_HISTORYEXIT,
-                isChecked = userPreferences.clearHistoryExitEnabled,
-                onCheckChange = { userPreferences.clearHistoryExitEnabled = it }
+            preference = SETTINGS_HISTORYEXIT,
+            isChecked = userPreferences.clearHistoryExitEnabled,
+            onCheckChange = { userPreferences.clearHistoryExitEnabled = it }
         )
 
         checkBoxPreference(
-                preference = SETTINGS_COOKIEEXIT,
-                isChecked = userPreferences.clearCookiesExitEnabled,
-                onCheckChange = { userPreferences.clearCookiesExitEnabled = it }
+            preference = SETTINGS_COOKIEEXIT,
+            isChecked = userPreferences.clearCookiesExitEnabled,
+            onCheckChange = { userPreferences.clearCookiesExitEnabled = it }
         )
 
         checkBoxPreference(
-                preference = SETTINGS_WEBSTORAGEEXIT,
-                isChecked = userPreferences.clearWebStorageExitEnabled,
-                onCheckChange = { userPreferences.clearWebStorageExitEnabled = it }
+            preference = SETTINGS_WEBSTORAGEEXIT,
+            isChecked = userPreferences.clearWebStorageExitEnabled,
+            onCheckChange = { userPreferences.clearWebStorageExitEnabled = it }
         )
 
         checkBoxPreference(
-                preference = SETTINGS_DONOTTRACK,
-                isChecked = userPreferences.doNotTrackEnabled && ApiUtils.doesSupportWebViewHeaders(),
-                isEnabled = ApiUtils.doesSupportWebViewHeaders(),
-                onCheckChange = { userPreferences.doNotTrackEnabled = it }
+            preference = SETTINGS_DONOTTRACK,
+            isChecked = userPreferences.doNotTrackEnabled && ApiUtils.doesSupportWebViewHeaders(),
+            isEnabled = ApiUtils.doesSupportWebViewHeaders(),
+            onCheckChange = { userPreferences.doNotTrackEnabled = it }
         )
 
         checkBoxPreference(
-                preference = SETTINGS_WEBRTC,
-                isChecked = userPreferences.webRtcEnabled && ApiUtils.doesSupportWebRtc(),
-                isEnabled = ApiUtils.doesSupportWebRtc(),
-                onCheckChange = { userPreferences.webRtcEnabled = it }
+            preference = SETTINGS_WEBRTC,
+            isChecked = userPreferences.webRtcEnabled && ApiUtils.doesSupportWebRtc(),
+            isEnabled = ApiUtils.doesSupportWebRtc(),
+            onCheckChange = { userPreferences.webRtcEnabled = it }
         )
 
         checkBoxPreference(
-                preference = SETTINGS_IDENTIFYINGHEADERS,
-                isChecked = userPreferences.removeIdentifyingHeadersEnabled && ApiUtils.doesSupportWebViewHeaders(),
-                isEnabled = ApiUtils.doesSupportWebViewHeaders(),
-                summary = "${LightningView.HEADER_REQUESTED_WITH}, ${LightningView.HEADER_WAP_PROFILE}",
-                onCheckChange = { userPreferences.removeIdentifyingHeadersEnabled = it }
+            preference = SETTINGS_IDENTIFYINGHEADERS,
+            isChecked = userPreferences.removeIdentifyingHeadersEnabled && ApiUtils.doesSupportWebViewHeaders(),
+            isEnabled = ApiUtils.doesSupportWebViewHeaders(),
+            summary = "${LightningView.HEADER_REQUESTED_WITH}, ${LightningView.HEADER_WAP_PROFILE}",
+            onCheckChange = { userPreferences.removeIdentifyingHeadersEnabled = it }
         )
 
     }
 
     private fun clearHistoryDialog() {
         BrowserDialog.showPositiveNegativeDialog(
-                activity = activity,
-                title = R.string.title_clear_history,
-                message = R.string.dialog_history,
-                positiveButton = DialogItem(R.string.action_yes) {
-                    clearHistory()
-                            .subscribeOn(databaseScheduler)
-                            .observeOn(AndroidSchedulers.mainThread())
-                            .subscribe {
-                                activity.snackbar(R.string.message_clear_history)
-                            }
-                },
-                negativeButton = DialogItem(R.string.action_no) {},
-                onCancel = {}
+            activity = activity,
+            title = R.string.title_clear_history,
+            message = R.string.dialog_history,
+            positiveButton = DialogItem(R.string.action_yes) {
+                clearHistory()
+                    .subscribeOn(databaseScheduler)
+                    .observeOn(mainScheduler)
+                    .subscribe {
+                        activity.snackbar(R.string.message_clear_history)
+                    }
+            },
+            negativeButton = DialogItem(R.string.action_no) {},
+            onCancel = {}
         )
     }
 
     private fun clearCookiesDialog() {
         BrowserDialog.showPositiveNegativeDialog(
-                activity = activity,
-                title = R.string.title_clear_cookies,
-                message = R.string.dialog_cookies,
-                positiveButton = DialogItem(R.string.action_yes) {
-                    clearCookies()
-                            .subscribeOn(databaseScheduler)
-                            .observeOn(AndroidSchedulers.mainThread())
-                            .subscribe {
-                                activity.snackbar(R.string.message_cookies_cleared)
-                            }
-                },
-                negativeButton = DialogItem(R.string.action_no) {},
-                onCancel = {}
+            activity = activity,
+            title = R.string.title_clear_cookies,
+            message = R.string.dialog_cookies,
+            positiveButton = DialogItem(R.string.action_yes) {
+                clearCookies()
+                    .subscribeOn(databaseScheduler)
+                    .observeOn(mainScheduler)
+                    .subscribe {
+                        activity.snackbar(R.string.message_cookies_cleared)
+                    }
+            },
+            negativeButton = DialogItem(R.string.action_no) {},
+            onCancel = {}
         )
     }
 

--- a/app/src/main/java/acr/browser/lightning/utils/Option.kt
+++ b/app/src/main/java/acr/browser/lightning/utils/Option.kt
@@ -1,0 +1,38 @@
+package acr.browser.lightning.utils
+
+/**
+ * An option type, taken from the Arrow library.
+ */
+sealed class Option<out T> {
+
+    /**
+     * A type representing the presences of [some] [T].
+     */
+    data class Some<T>(val some: T) : Option<T>()
+
+    /**
+     * A type representing the absence of [T].
+     */
+    object None : Option<Nothing>()
+
+    companion object {
+        /**
+         * Creates an [Option] from the potentially nullable [value].
+         */
+        fun <T> fromNullable(value: T?): Option<T> =
+            if (value != null) {
+                Option.Some(value)
+            } else {
+                Option.None
+            }
+    }
+
+}
+
+/**
+ * Returns the value held by the [Option] as a nullable [T].
+ */
+fun <T> Option<T>.value(): T? = when (this) {
+    is Option.Some -> some
+    Option.None -> null
+}

--- a/app/src/main/java/acr/browser/lightning/view/LightningChromeClient.kt
+++ b/app/src/main/java/acr/browser/lightning/view/LightningChromeClient.kt
@@ -3,6 +3,7 @@ package acr.browser.lightning.view
 import acr.browser.lightning.BrowserApp
 import acr.browser.lightning.R
 import acr.browser.lightning.controller.UIController
+import acr.browser.lightning.di.DiskScheduler
 import acr.browser.lightning.dialog.BrowserDialog
 import acr.browser.lightning.dialog.DialogItem
 import acr.browser.lightning.extensions.resizeAndShow
@@ -38,7 +39,7 @@ class LightningChromeClient(
     @Inject internal lateinit var faviconModel: FaviconModel
     @Inject internal lateinit var userPreferences: UserPreferences
     @Inject internal lateinit var webRtcPermissionsModel: WebRtcPermissionsModel
-    @Inject @field:Named("disk") internal lateinit var diskScheduler: Scheduler
+    @Inject @field:DiskScheduler internal lateinit var diskScheduler: Scheduler
 
     init {
         BrowserApp.appComponent.inject(this)

--- a/app/src/main/java/acr/browser/lightning/view/LightningView.kt
+++ b/app/src/main/java/acr/browser/lightning/view/LightningView.kt
@@ -10,6 +10,7 @@ import acr.browser.lightning.constant.MOBILE_USER_AGENT
 import acr.browser.lightning.constant.SCHEME_BOOKMARKS
 import acr.browser.lightning.constant.SCHEME_HOMEPAGE
 import acr.browser.lightning.controller.UIController
+import acr.browser.lightning.di.DatabaseScheduler
 import acr.browser.lightning.dialog.LightningDialogBuilder
 import acr.browser.lightning.download.LightningDownloadListener
 import acr.browser.lightning.html.bookmark.BookmarkPage
@@ -42,7 +43,6 @@ import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
 import java.lang.ref.WeakReference
 import javax.inject.Inject
-import javax.inject.Named
 
 /**
  * [LightningView] acts as a tab for the browser, handling WebView creation and handling logic, as
@@ -113,7 +113,7 @@ class LightningView(
     @Inject internal lateinit var userPreferences: UserPreferences
     @Inject internal lateinit var dialogBuilder: LightningDialogBuilder
     @Inject internal lateinit var proxyUtils: ProxyUtils
-    @Inject @field:Named("database") internal lateinit var databaseScheduler: Scheduler
+    @Inject @field:DatabaseScheduler internal lateinit var databaseScheduler: Scheduler
 
     private val lightningWebClient: LightningWebClient
 

--- a/app/src/main/java/acr/browser/lightning/view/LightningView.kt
+++ b/app/src/main/java/acr/browser/lightning/view/LightningView.kt
@@ -11,6 +11,7 @@ import acr.browser.lightning.constant.SCHEME_BOOKMARKS
 import acr.browser.lightning.constant.SCHEME_HOMEPAGE
 import acr.browser.lightning.controller.UIController
 import acr.browser.lightning.di.DatabaseScheduler
+import acr.browser.lightning.di.MainScheduler
 import acr.browser.lightning.dialog.LightningDialogBuilder
 import acr.browser.lightning.download.LightningDownloadListener
 import acr.browser.lightning.html.bookmark.BookmarkPage
@@ -40,7 +41,6 @@ import android.webkit.WebView
 import io.reactivex.Observable
 import io.reactivex.Scheduler
 import io.reactivex.Single
-import io.reactivex.android.schedulers.AndroidSchedulers
 import java.lang.ref.WeakReference
 import javax.inject.Inject
 
@@ -114,6 +114,7 @@ class LightningView(
     @Inject internal lateinit var dialogBuilder: LightningDialogBuilder
     @Inject internal lateinit var proxyUtils: ProxyUtils
     @Inject @field:DatabaseScheduler internal lateinit var databaseScheduler: Scheduler
+    @Inject @field:MainScheduler internal lateinit var mainScheduler: Scheduler
 
     private val lightningWebClient: LightningWebClient
 
@@ -235,7 +236,7 @@ class LightningView(
         StartPage()
             .createHomePage()
             .subscribeOn(databaseScheduler)
-            .observeOn(AndroidSchedulers.mainThread())
+            .observeOn(mainScheduler)
             .subscribe(this::loadUrl)
     }
 
@@ -247,7 +248,7 @@ class LightningView(
         BookmarkPage(activity)
             .createBookmarkPage()
             .subscribeOn(databaseScheduler)
-            .observeOn(AndroidSchedulers.mainThread())
+            .observeOn(mainScheduler)
             .subscribe(this::loadUrl)
     }
 
@@ -259,7 +260,7 @@ class LightningView(
         DownloadsPage()
             .getDownloadsPage()
             .subscribeOn(databaseScheduler)
-            .observeOn(AndroidSchedulers.mainThread())
+            .observeOn(mainScheduler)
             .subscribe(this::loadUrl)
     }
 
@@ -389,7 +390,7 @@ class LightningView(
 
         getPathObservable("appcache")
             .subscribeOn(databaseScheduler)
-            .observeOn(AndroidSchedulers.mainThread())
+            .observeOn(mainScheduler)
             .subscribe { file ->
                 settings.setAppCachePath(file.path)
             }
@@ -397,7 +398,7 @@ class LightningView(
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             getPathObservable("geolocation")
                 .subscribeOn(databaseScheduler)
-                .observeOn(AndroidSchedulers.mainThread())
+                .observeOn(mainScheduler)
                 .subscribe { file ->
                     settings.setGeolocationDatabasePath(file.path)
                 }


### PR DESCRIPTION
# Summary
- Simplified the tab manager initialization logic by converting initialization to more idiomatic Rx streams based approach.
- Maintained certain side effects by utilizing `doOnNext` or `doOnSuccess`
- `initializeTabs` now emits the last initialized tab so that it can be displayed in the UI.
- Added a delayed initialization `TabInitializer` that requests the user's permission to initialize it.
- Added observable extensions
- Added an `Option` type taken from Arrow (not enough types are currently needed to pull in whole library)