### PR TITLE
Fixing play store build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,6 +37,10 @@ android {
             shrinkResources true
             proguardFiles 'proguard-project.txt'
             testCoverageEnabled false
+
+            ndk {
+                abiFilters "arm64-v8a", "armeabi-v7a", "armeabi", "mips"
+            }
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,5 +27,5 @@ ext {
 
     versionName = '5.0.1'
     versionCode_lite = 100
-    versionCode_plus = 98
+    versionCode_plus = 99
 }


### PR DESCRIPTION
Exclude x86 architecture since there is no x86_64 library available, preventing play deploy