### PR TITLE
HTTPS icon stands out on dark and night mode

### DIFF
--- a/app/src/main/java/acr/browser/lightning/ssl/SslIcon.kt
+++ b/app/src/main/java/acr/browser/lightning/ssl/SslIcon.kt
@@ -2,6 +2,7 @@ package acr.browser.lightning.ssl
 
 import acr.browser.lightning.R
 import acr.browser.lightning.utils.DrawableUtils
+import acr.browser.lightning.utils.ThemeUtils
 import android.content.Context
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
@@ -12,12 +13,14 @@ import android.graphics.drawable.Drawable
 fun Context.createSslDrawableForState(sslState: SslState): Drawable? = when (sslState) {
     is SslState.None -> null
     is SslState.Valid -> {
-        val bitmap = DrawableUtils.createImageInsetInRoundedSquare(this, R.drawable.ic_secured)
+        val drawableBackgroundColor = ThemeUtils.getPrimaryColor(this)
+        val bitmap = DrawableUtils.createImageInsetInRoundedSquare(this, R.drawable.ic_secured, drawableBackgroundColor)
         val securedDrawable = BitmapDrawable(resources, bitmap)
         securedDrawable
     }
     is SslState.Invalid -> {
-        val bitmap = DrawableUtils.createImageInsetInRoundedSquare(this, R.drawable.ic_unsecured)
+        val drawableBackgroundColor = ThemeUtils.getPrimaryColor(this)
+        val bitmap = DrawableUtils.createImageInsetInRoundedSquare(this, R.drawable.ic_unsecured, drawableBackgroundColor)
         val unsecuredDrawable = BitmapDrawable(resources, bitmap)
         unsecuredDrawable
     }

--- a/app/src/main/java/acr/browser/lightning/ssl/SslIcon.kt
+++ b/app/src/main/java/acr/browser/lightning/ssl/SslIcon.kt
@@ -13,13 +13,13 @@ import android.graphics.drawable.Drawable
 fun Context.createSslDrawableForState(sslState: SslState): Drawable? = when (sslState) {
     is SslState.None -> null
     is SslState.Valid -> {
-        val drawableBackgroundColor = ThemeUtils.getPrimaryColor(this)
+        val drawableBackgroundColor = ThemeUtils.getColor(this, R.attr.drawerBackground)
         val bitmap = DrawableUtils.createImageInsetInRoundedSquare(this, R.drawable.ic_secured, drawableBackgroundColor)
         val securedDrawable = BitmapDrawable(resources, bitmap)
         securedDrawable
     }
     is SslState.Invalid -> {
-        val drawableBackgroundColor = ThemeUtils.getPrimaryColor(this)
+        val drawableBackgroundColor = ThemeUtils.getColor(this, R.attr.drawerBackground)
         val bitmap = DrawableUtils.createImageInsetInRoundedSquare(this, R.drawable.ic_unsecured, drawableBackgroundColor)
         val unsecuredDrawable = BitmapDrawable(resources, bitmap)
         unsecuredDrawable

--- a/app/src/main/java/acr/browser/lightning/utils/DrawableUtils.java
+++ b/app/src/main/java/acr/browser/lightning/utils/DrawableUtils.java
@@ -23,21 +23,23 @@ public final class DrawableUtils {
     private DrawableUtils() {}
 
     /**
-     * Creates a white rounded drawable with an inset image of a different color.
+     * Creates a rounded drawable witch chosen color with an inset image of a different color.
      *
      * @param context     the context needed to work with resources.
      * @param drawableRes the drawable to inset on the rounded drawable.
+     * @param color       the color of rounded drawable
      * @return a bitmap with the desired content.
      */
     @NonNull
     public static Bitmap createImageInsetInRoundedSquare(Context context,
-                                                         @DrawableRes int drawableRes) {
+                                                         @DrawableRes int drawableRes,
+                                                         @ColorInt int color) {
         final Bitmap icon = ThemeUtils.getBitmapFromVectorDrawable(context, drawableRes);
 
         final Bitmap image = Bitmap.createBitmap(icon.getWidth(), icon.getHeight(), Bitmap.Config.ARGB_8888);
         final Canvas canvas = new Canvas(image);
         final Paint paint = new Paint();
-        paint.setColor(Color.WHITE);
+        paint.setColor(color);
         paint.setAntiAlias(true);
         paint.setFilterBitmap(true);
         paint.setDither(true);


### PR DESCRIPTION
Setting background color of sslDrawable to color matching currlenty selected theme. 
In my opinion `drawerBackground` was the most suitable color for this task.
Fixes #766 