### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: android
 sudo: false
+cache:
+  directories:
+    - $HOME/.gradle
 jdk:
   - oraclejdk8
 android:


### PR DESCRIPTION
Would be interested to know why gradle dependencies haven't been cached on Travis. Thank you.