### PR TITLE
Disable jetifier

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -170,7 +170,6 @@ mezzanine {
 kapt {
     correctErrorTypes = true
     useBuildCache = true
-    generateStubs = true
 }
 
 kotlin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 android.useAndroidX=true
-android.enableJetifier=true
 
 org.gradle.daemon=true
 org.gradle.parallel=true
@@ -7,8 +6,6 @@ org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4096m
 org.gradle.unsafe.configuration-cache=true
 
-ANDROID_BUILD_TARGET_SDK_VERSION=28
-ANDROID_BUILD_SDK_VERSION=28
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
Jetifier is no longer needed and is actually causing some issues with newer dependencies. Also removed some other irrelevant gradle options.