### PR TITLE
Fix ephemeral tab closing behavior

### DIFF
--- a/app/src/main/java/acr/browser/lightning/browser/BrowserContract.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/BrowserContract.kt
@@ -192,7 +192,7 @@ interface BrowserContract {
          */
         fun createTab(
             tabInitializer: TabInitializer,
-            isEphemeral: Boolean = false
+            tabType: TabModel.Type = TabModel.Type.NORMAL
         ): Single<TabModel>
 
         /**

--- a/app/src/main/java/acr/browser/lightning/browser/BrowserPresenter.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/BrowserPresenter.kt
@@ -279,7 +279,7 @@ class BrowserPresenter @Inject constructor(
                 createNewTabAndSelect(
                     tabInitializer = it,
                     shouldSelect = true,
-                    markAsOpenedFromAction = true
+                    tabType = TabModel.Type.POP_UP
                 )
             }
 
@@ -348,7 +348,7 @@ class BrowserPresenter @Inject constructor(
                 createNewTabAndSelect(
                     tabInitializer = UrlInitializer(action.url),
                     shouldSelect = true,
-                    markAsOpenedFromAction = true
+                    tabType = TabModel.Type.EPHEMERAL
                 )
             }
 
@@ -367,7 +367,7 @@ class BrowserPresenter @Inject constructor(
                 createNewTabAndSelect(
                     tabInitializer = UrlInitializer(it.url),
                     shouldSelect = true,
-                    markAsOpenedFromAction = true
+                    tabType = TabModel.Type.EPHEMERAL
                 )
             }
         }
@@ -435,9 +435,9 @@ class BrowserPresenter @Inject constructor(
     private fun createNewTabAndSelect(
         tabInitializer: TabInitializer,
         shouldSelect: Boolean,
-        markAsOpenedFromAction: Boolean = false
+        tabType: TabModel.Type = TabModel.Type.NORMAL
     ) {
-        compositeDisposable += model.createTab(tabInitializer, isEphemeral = markAsOpenedFromAction)
+        compositeDisposable += model.createTab(tabInitializer, tabType = tabType)
             .observeOn(mainScheduler)
             .subscribe { tab ->
                 if (shouldSelect) {
@@ -523,7 +523,7 @@ class BrowserPresenter @Inject constructor(
             .subscribe {
                 if (needToSelectNextTab) {
                     nextTab?.id?.let {
-                        val shouldClose = currentTab?.isEphemeral ?: false
+                        val shouldClose = currentTab?.tabType == TabModel.Type.EPHEMERAL
                         selectTab(model.selectTab(it), focusTab = false)
                         if (shouldClose) {
                             navigator.backgroundBrowser()
@@ -578,7 +578,7 @@ class BrowserPresenter @Inject constructor(
                 currentTab?.id?.let {
                     view?.showCloseBrowserDialog(it)
                 }
-            } else if (currentTab?.isEphemeral == true) {
+            } else if (currentTab?.tabType in listOf(TabModel.Type.EPHEMERAL, TabModel.Type.POP_UP)) {
                 onTabClose(tabListState.indexOfCurrentTab())
             } else {
                 navigator.backgroundBrowser()

--- a/app/src/main/java/acr/browser/lightning/browser/tab/TabAdapter.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/tab/TabAdapter.kt
@@ -45,7 +45,7 @@ class TabAdapter @AssistedInject constructor(
     @Assisted private val webView: WebView,
     @Assisted private val requestHeaders: Map<String, String>,
     @Assisted private val tabWebViewClient: TabWebViewClient,
-    @Assisted override var isEphemeral: Boolean,
+    @Assisted override var tabType: TabModel.Type,
     private val tabWebChromeClient: TabWebChromeClient,
     private val userPreferences: UserPreferences,
     @DefaultUserAgent private val defaultUserAgent: String,
@@ -65,7 +65,7 @@ class TabAdapter @AssistedInject constructor(
             webView: WebView,
             requestHeaders: Map<String, String>,
             tabWebViewClient: TabWebViewClient,
-            isEphemeral: Boolean,
+            tabType: TabModel.Type,
         ): TabAdapter
     }
 

--- a/app/src/main/java/acr/browser/lightning/browser/tab/TabFactory.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/tab/TabFactory.kt
@@ -33,7 +33,7 @@ class TabFactory @Inject constructor(
     fun constructTab(
         tabInitializer: TabInitializer,
         webView: WebView,
-        isEphemeral: Boolean
+        tabType: TabModel.Type
     ): Single<TabModel> {
         val faviconHandler = cacheDirThreadSafeFileProvider.file()
             .map { InternalStoragePathHandler(app, File(it, "favicon-cache")) }
@@ -54,7 +54,7 @@ class TabFactory @Inject constructor(
                         faviconHandler,
                         htmlHandler
                     ),
-                    isEphemeral,
+                    tabType,
                 )
             }
     }

--- a/app/src/main/java/acr/browser/lightning/browser/tab/TabModel.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/tab/TabModel.kt
@@ -23,10 +23,9 @@ interface TabModel {
     val id: Int
 
     /**
-     * True if the tab is ephemeral and should be deleted when the browser is closed, false
-     * otherwise.
+     * The type of tab this is, defined by its origin.
      */
-    var isEphemeral: Boolean
+    var tabType: Type
 
     // Navigation
 
@@ -255,4 +254,10 @@ interface TabModel {
      * Freeze the current state of the tab and return it as a [Bundle].
      */
     fun freeze(): Bundle
+
+    enum class Type {
+        NORMAL,
+        EPHEMERAL,
+        POP_UP
+    }
 }


### PR DESCRIPTION
Split tab types into 3 types
- normal
- ephemeral
- popup

normal tabs behave normally. ephemeral tabs close the browser when they are closed, and can be closed by pressing the back button. popup tabs can be closed by pressing the back button.