### PR TITLE
Fix rendering threading

### DIFF
--- a/app/src/main/java/acr/browser/lightning/browser/tab/TabAdapter.kt
+++ b/app/src/main/java/acr/browser/lightning/browser/tab/TabAdapter.kt
@@ -189,8 +189,9 @@ class TabAdapter @AssistedInject constructor(
     override fun previewChanges(): Observable<Pair<String?, Long>> =
         tabWebViewClient.finishedObservable
             .debounce(100, TimeUnit.MILLISECONDS)
-            .observeOn(diskScheduler)
+            .observeOn(mainScheduler)
             .mapOptional { Optional.ofNullable(renderViewToBitmap(webView)) }
+            .observeOn(diskScheduler)
             .flatMapSingle { bitmap ->
                 previewModel.cachePreviewForId(webView.id, bitmap)
                     .andThen(previewPathSingle)


### PR DESCRIPTION
renderViewToBitmap should run on the main thread, as it can crash if the main thread is blocked while we try to render from another thread.