### PR TITLE
Reenable lite build

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -22,5 +22,3 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
       - name: Build
         run: ./gradlew build
-      - name: Check
-        run: ./gradlew checkSortDependencies

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,6 +92,7 @@ android {
         }
     }
     lint {
+        checkReleaseBuilds = false
         abortOnError = true
     }
     namespace = "acr.browser.lightning"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,10 +30,8 @@ android {
         create("lightningPlus").apply {
             setRoot("src/LightningPlus")
         }
-        if (!isCi) {
-            create("lightningLite").apply {
-                setRoot("src/LightningLite")
-            }
+        create("lightningLite").apply {
+            setRoot("src/LightningLite")
         }
     }
 
@@ -81,14 +79,11 @@ android {
             applicationId = "acr.browser.lightning"
             versionCode = commonVersionCode
         }
-
-        if (!isCi) {
-            create("lightningLite") {
-                dimension = "capabilities"
-                buildConfigField("boolean", "FULL_VERSION", "Boolean.parseBoolean(\"false\")")
-                applicationId = "acr.browser.barebones"
-                versionCode = commonVersionCode
-            }
+        create("lightningLite") {
+            dimension = "capabilities"
+            buildConfigField("boolean", "FULL_VERSION", "Boolean.parseBoolean(\"false\")")
+            applicationId = "acr.browser.barebones"
+            versionCode = commonVersionCode
         }
     }
     packaging {


### PR DESCRIPTION
- Reenable lite build so that renovate updates lock file correctly
- Disable lint on release builds to avoid unnecessary work
- Remove extra dependency sorting task in actions since build already runs it